### PR TITLE
PLT-463 - Standard IBOR and Overnight indices

### DIFF
--- a/basics/src/main/java/com/opengamma/basics/index/IborIndex.java
+++ b/basics/src/main/java/com/opengamma/basics/index/IborIndex.java
@@ -1,0 +1,780 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.date.DayCount;
+import com.opengamma.basics.date.DaysAdjustment;
+import com.opengamma.basics.date.HolidayCalendar;
+import com.opengamma.basics.date.HolidayCalendars;
+import com.opengamma.basics.date.Tenor;
+import com.opengamma.basics.date.TenorAdjustment;
+import com.opengamma.collect.ArgChecker;
+
+/**
+ * An IBOR-like index, such as Libor or Euribor.
+ * <p>
+ * An index represented by this class relates to inter-bank lending for periods
+ * from one day to one year. They are typically calculated and published as the
+ * trimmed arithmetic mean of estimated rates contributed by banks.
+ * <p>
+ * The index is defined by four dates.
+ * The fixing date is the date on which the index is to be observed.
+ * The publication date is the date on which the fixed rate is actually published.
+ * The effective date is the date on which the implied deposit starts.
+ * The maturity date is the date on which the implied deposit ends.
+ */
+@BeanDefinition(cacheHashCode = true)
+public final class IborIndex
+    implements RateIndex, ImmutableBean, Serializable {
+
+  /**
+   * Serialization version.
+   */
+  private static final long serialVersionUID = 1;
+
+  /**
+   * The currency of the index.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final Currency currency;
+  /**
+   * The index name, such as 'GBP-LIBOR-3M'.
+   */
+  @PropertyDefinition(validate = "notEmpty", overrideGet = true)
+  private final String name;
+  /**
+   * The calendar that the fixing date follows.
+   * <p>
+   * The fixing date is when the rate is determined.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final HolidayCalendar fixingCalendar;
+  /**
+   * The adjustment applied to the fixing date to obtain the effective date.
+   * <p>
+   * The effective date is the start date of the indexed deposit.
+   * In most cases, the effective date is 0 or 2 days after the fixing date.
+   * This data structure allows the complex rules of some indices to be represented.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final DaysAdjustment effectiveDateOffset;
+  /**
+   * The adjustment applied to the effective date to obtain the maturity date.
+   * <p>
+   * The maturity date is the end date of the indexed deposit and is relative to the effective date.
+   * This data structure allows the complex rules of some indices to be represented.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final TenorAdjustment maturityDateOffset;
+  /**
+   * The day count convention.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final DayCount dayCount;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains a {@code IborIndex} from a unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the index
+   * @throws IllegalArgumentException if the name is not known
+   */
+  public static IborIndex of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return RateIndices.ENUM_LOOKUP.lookup(uniqueName, IborIndex.class);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns the name of the index.
+   * 
+   * @return the name of the index
+   */
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the type of the index, which is tenor.
+   * 
+   * @return the index type
+   */
+  @Override
+  public RateIndexType getType() {
+    return RateIndexType.TENOR;
+  }
+
+  /**
+   * Gets the tenor of the index.
+   * 
+   * @return the tenor
+   */
+  @Override
+  public Tenor getTenor() {
+    return maturityDateOffset.getTenor();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the publication date from the fixing date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The publication date is the date on which the fixed rate is actually published.
+   * <p>
+   * An IBOR-like index is always published on the same day as the fixing date.
+   * <p>
+   * No error is thrown if the input date is not a valid fixing date.
+   * Instead, the fixing date is moved to the next business day and then processed.
+   * 
+   * @param fixingDate  the fixing date
+   * @return the publication date
+   */
+  @Override
+  public LocalDate calculatePublicationFromFixing(LocalDate fixingDate) {
+    ArgChecker.notNull(fixingDate, "fixingDate");
+    return fixingCalendar.nextOrSame(fixingDate);
+  }
+
+  /**
+   * Calculates the effective date from the fixing date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The effective date is the date on which the implied deposit starts.
+   * <p>
+   * No error is thrown if the input date is not a valid fixing date.
+   * Instead, the fixing date is moved to the next business day and then processed.
+   * 
+   * @param fixingDate  the fixing date
+   * @return the effective date
+   */
+  @Override
+  public LocalDate calculateEffectiveFromFixing(LocalDate fixingDate) {
+    ArgChecker.notNull(fixingDate, "fixingDate");
+    LocalDate fixingBusinessDay = fixingCalendar.nextOrSame(fixingDate);
+    return effectiveDateOffset.adjust(fixingBusinessDay);
+  }
+
+  /**
+   * Calculates the fixing date from the effective date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The effective date is the date on which the implied deposit starts.
+   * <p>
+   * No error is thrown if the input date is not a valid effective date.
+   * Instead, the effective date is moved to the next business day and then processed.
+   * 
+   * @param effectiveDate  the effective date
+   * @return the fixing date
+   */
+  @Override
+  public LocalDate calculateFixingFromEffective(LocalDate effectiveDate)  {
+    ArgChecker.notNull(effectiveDate, "effectiveDate");
+    LocalDate effectiveBusinessDay = effectiveDateCalendar().nextOrSame(effectiveDate);
+    LocalDate fixingDate = effectiveBusinessDay;
+    while (effectiveDateOffset.adjust(fixingDate).isAfter(effectiveBusinessDay) || fixingCalendar.isHoliday(fixingDate)) {
+      fixingDate = fixingDate.minusDays(1);
+    }
+    return fixingDate;
+  }
+
+  /**
+   * Calculates the maturity date from the effective date.
+   * <p>
+   * The effective date is the date on which the implied deposit starts.
+   * The maturity date is the date on which the implied deposit ends.
+   * <p>
+   * No error is thrown if the input date is not a valid effective date.
+   * Instead, the effective date is moved to the next business day and then processed.
+   * 
+   * @param effectiveDate  the effective date
+   * @return the maturity date
+   */
+  @Override
+  public LocalDate calculateMaturityFromEffective(LocalDate effectiveDate) {
+    ArgChecker.notNull(effectiveDate, "effectiveDate");
+    LocalDate effectiveBusinessDay = effectiveDateCalendar().nextOrSame(effectiveDate);
+    return maturityDateOffset.adjust(effectiveBusinessDay);
+  }
+
+  // finds the calendar of the effective date
+  private HolidayCalendar effectiveDateCalendar() {
+    HolidayCalendar cal = effectiveDateOffset.getAdjustment().getCalendar();
+    if (cal == HolidayCalendars.NO_HOLIDAYS) {
+      cal = effectiveDateOffset.getCalendar();
+      if (cal == HolidayCalendars.NO_HOLIDAYS) {
+        cal = fixingCalendar;
+      }
+    }
+    return cal;
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code IborIndex}.
+   * @return the meta-bean, not null
+   */
+  public static IborIndex.Meta meta() {
+    return IborIndex.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(IborIndex.Meta.INSTANCE);
+  }
+
+  /**
+   * The cached hash code, using the racy single-check idiom.
+   */
+  private int cachedHashCode;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static IborIndex.Builder builder() {
+    return new IborIndex.Builder();
+  }
+
+  private IborIndex(
+      Currency currency,
+      String name,
+      HolidayCalendar fixingCalendar,
+      DaysAdjustment effectiveDateOffset,
+      TenorAdjustment maturityDateOffset,
+      DayCount dayCount) {
+    JodaBeanUtils.notNull(currency, "currency");
+    JodaBeanUtils.notEmpty(name, "name");
+    JodaBeanUtils.notNull(fixingCalendar, "fixingCalendar");
+    JodaBeanUtils.notNull(effectiveDateOffset, "effectiveDateOffset");
+    JodaBeanUtils.notNull(maturityDateOffset, "maturityDateOffset");
+    JodaBeanUtils.notNull(dayCount, "dayCount");
+    this.currency = currency;
+    this.name = name;
+    this.fixingCalendar = fixingCalendar;
+    this.effectiveDateOffset = effectiveDateOffset;
+    this.maturityDateOffset = maturityDateOffset;
+    this.dayCount = dayCount;
+  }
+
+  @Override
+  public IborIndex.Meta metaBean() {
+    return IborIndex.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the currency of the index.
+   * @return the value of the property, not null
+   */
+  @Override
+  public Currency getCurrency() {
+    return currency;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the index name, such as 'GBP-LIBOR-3M'.
+   * @return the value of the property, not empty
+   */
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the calendar that the fixing date follows.
+   * <p>
+   * The fixing date is when the rate is determined.
+   * @return the value of the property, not null
+   */
+  public HolidayCalendar getFixingCalendar() {
+    return fixingCalendar;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the adjustment applied to the fixing date to obtain the effective date.
+   * <p>
+   * The effective date is the start date of the indexed deposit.
+   * In most cases, the effective date is 0 or 2 days after the fixing date.
+   * This data structure allows the complex rules of some indices to be represented.
+   * @return the value of the property, not null
+   */
+  public DaysAdjustment getEffectiveDateOffset() {
+    return effectiveDateOffset;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the adjustment applied to the effective date to obtain the maturity date.
+   * <p>
+   * The maturity date is the end date of the indexed deposit and is relative to the effective date.
+   * This data structure allows the complex rules of some indices to be represented.
+   * @return the value of the property, not null
+   */
+  public TenorAdjustment getMaturityDateOffset() {
+    return maturityDateOffset;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the day count convention.
+   * @return the value of the property, not null
+   */
+  @Override
+  public DayCount getDayCount() {
+    return dayCount;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      IborIndex other = (IborIndex) obj;
+      return JodaBeanUtils.equal(getCurrency(), other.getCurrency()) &&
+          JodaBeanUtils.equal(getName(), other.getName()) &&
+          JodaBeanUtils.equal(getFixingCalendar(), other.getFixingCalendar()) &&
+          JodaBeanUtils.equal(getEffectiveDateOffset(), other.getEffectiveDateOffset()) &&
+          JodaBeanUtils.equal(getMaturityDateOffset(), other.getMaturityDateOffset()) &&
+          JodaBeanUtils.equal(getDayCount(), other.getDayCount());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = cachedHashCode;
+    if (hash == 0) {
+      hash = getClass().hashCode();
+      hash += hash * 31 + JodaBeanUtils.hashCode(getCurrency());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getName());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getFixingCalendar());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getEffectiveDateOffset());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getMaturityDateOffset());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getDayCount());
+      cachedHashCode = hash;
+    }
+    return hash;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code IborIndex}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code currency} property.
+     */
+    private final MetaProperty<Currency> currency = DirectMetaProperty.ofImmutable(
+        this, "currency", IborIndex.class, Currency.class);
+    /**
+     * The meta-property for the {@code name} property.
+     */
+    private final MetaProperty<String> name = DirectMetaProperty.ofImmutable(
+        this, "name", IborIndex.class, String.class);
+    /**
+     * The meta-property for the {@code fixingCalendar} property.
+     */
+    private final MetaProperty<HolidayCalendar> fixingCalendar = DirectMetaProperty.ofImmutable(
+        this, "fixingCalendar", IborIndex.class, HolidayCalendar.class);
+    /**
+     * The meta-property for the {@code effectiveDateOffset} property.
+     */
+    private final MetaProperty<DaysAdjustment> effectiveDateOffset = DirectMetaProperty.ofImmutable(
+        this, "effectiveDateOffset", IborIndex.class, DaysAdjustment.class);
+    /**
+     * The meta-property for the {@code maturityDateOffset} property.
+     */
+    private final MetaProperty<TenorAdjustment> maturityDateOffset = DirectMetaProperty.ofImmutable(
+        this, "maturityDateOffset", IborIndex.class, TenorAdjustment.class);
+    /**
+     * The meta-property for the {@code dayCount} property.
+     */
+    private final MetaProperty<DayCount> dayCount = DirectMetaProperty.ofImmutable(
+        this, "dayCount", IborIndex.class, DayCount.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "currency",
+        "name",
+        "fixingCalendar",
+        "effectiveDateOffset",
+        "maturityDateOffset",
+        "dayCount");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          return currency;
+        case 3373707:  // name
+          return name;
+        case 394230283:  // fixingCalendar
+          return fixingCalendar;
+        case 1571923688:  // effectiveDateOffset
+          return effectiveDateOffset;
+        case 1574797394:  // maturityDateOffset
+          return maturityDateOffset;
+        case 1905311443:  // dayCount
+          return dayCount;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public IborIndex.Builder builder() {
+      return new IborIndex.Builder();
+    }
+
+    @Override
+    public Class<? extends IborIndex> beanType() {
+      return IborIndex.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code currency} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Currency> currency() {
+      return currency;
+    }
+
+    /**
+     * The meta-property for the {@code name} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<String> name() {
+      return name;
+    }
+
+    /**
+     * The meta-property for the {@code fixingCalendar} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<HolidayCalendar> fixingCalendar() {
+      return fixingCalendar;
+    }
+
+    /**
+     * The meta-property for the {@code effectiveDateOffset} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<DaysAdjustment> effectiveDateOffset() {
+      return effectiveDateOffset;
+    }
+
+    /**
+     * The meta-property for the {@code maturityDateOffset} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<TenorAdjustment> maturityDateOffset() {
+      return maturityDateOffset;
+    }
+
+    /**
+     * The meta-property for the {@code dayCount} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<DayCount> dayCount() {
+      return dayCount;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          return ((IborIndex) bean).getCurrency();
+        case 3373707:  // name
+          return ((IborIndex) bean).getName();
+        case 394230283:  // fixingCalendar
+          return ((IborIndex) bean).getFixingCalendar();
+        case 1571923688:  // effectiveDateOffset
+          return ((IborIndex) bean).getEffectiveDateOffset();
+        case 1574797394:  // maturityDateOffset
+          return ((IborIndex) bean).getMaturityDateOffset();
+        case 1905311443:  // dayCount
+          return ((IborIndex) bean).getDayCount();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code IborIndex}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<IborIndex> {
+
+    private Currency currency;
+    private String name;
+    private HolidayCalendar fixingCalendar;
+    private DaysAdjustment effectiveDateOffset;
+    private TenorAdjustment maturityDateOffset;
+    private DayCount dayCount;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(IborIndex beanToCopy) {
+      this.currency = beanToCopy.getCurrency();
+      this.name = beanToCopy.getName();
+      this.fixingCalendar = beanToCopy.getFixingCalendar();
+      this.effectiveDateOffset = beanToCopy.getEffectiveDateOffset();
+      this.maturityDateOffset = beanToCopy.getMaturityDateOffset();
+      this.dayCount = beanToCopy.getDayCount();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          return currency;
+        case 3373707:  // name
+          return name;
+        case 394230283:  // fixingCalendar
+          return fixingCalendar;
+        case 1571923688:  // effectiveDateOffset
+          return effectiveDateOffset;
+        case 1574797394:  // maturityDateOffset
+          return maturityDateOffset;
+        case 1905311443:  // dayCount
+          return dayCount;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          this.currency = (Currency) newValue;
+          break;
+        case 3373707:  // name
+          this.name = (String) newValue;
+          break;
+        case 394230283:  // fixingCalendar
+          this.fixingCalendar = (HolidayCalendar) newValue;
+          break;
+        case 1571923688:  // effectiveDateOffset
+          this.effectiveDateOffset = (DaysAdjustment) newValue;
+          break;
+        case 1574797394:  // maturityDateOffset
+          this.maturityDateOffset = (TenorAdjustment) newValue;
+          break;
+        case 1905311443:  // dayCount
+          this.dayCount = (DayCount) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public IborIndex build() {
+      return new IborIndex(
+          currency,
+          name,
+          fixingCalendar,
+          effectiveDateOffset,
+          maturityDateOffset,
+          dayCount);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the {@code currency} property in the builder.
+     * @param currency  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder currency(Currency currency) {
+      JodaBeanUtils.notNull(currency, "currency");
+      this.currency = currency;
+      return this;
+    }
+
+    /**
+     * Sets the {@code name} property in the builder.
+     * @param name  the new value, not empty
+     * @return this, for chaining, not null
+     */
+    public Builder name(String name) {
+      JodaBeanUtils.notEmpty(name, "name");
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the {@code fixingCalendar} property in the builder.
+     * @param fixingCalendar  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder fixingCalendar(HolidayCalendar fixingCalendar) {
+      JodaBeanUtils.notNull(fixingCalendar, "fixingCalendar");
+      this.fixingCalendar = fixingCalendar;
+      return this;
+    }
+
+    /**
+     * Sets the {@code effectiveDateOffset} property in the builder.
+     * @param effectiveDateOffset  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder effectiveDateOffset(DaysAdjustment effectiveDateOffset) {
+      JodaBeanUtils.notNull(effectiveDateOffset, "effectiveDateOffset");
+      this.effectiveDateOffset = effectiveDateOffset;
+      return this;
+    }
+
+    /**
+     * Sets the {@code maturityDateOffset} property in the builder.
+     * @param maturityDateOffset  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder maturityDateOffset(TenorAdjustment maturityDateOffset) {
+      JodaBeanUtils.notNull(maturityDateOffset, "maturityDateOffset");
+      this.maturityDateOffset = maturityDateOffset;
+      return this;
+    }
+
+    /**
+     * Sets the {@code dayCount} property in the builder.
+     * @param dayCount  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder dayCount(DayCount dayCount) {
+      JodaBeanUtils.notNull(dayCount, "dayCount");
+      this.dayCount = dayCount;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(224);
+      buf.append("IborIndex.Builder{");
+      buf.append("currency").append('=').append(JodaBeanUtils.toString(currency)).append(',').append(' ');
+      buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
+      buf.append("fixingCalendar").append('=').append(JodaBeanUtils.toString(fixingCalendar)).append(',').append(' ');
+      buf.append("effectiveDateOffset").append('=').append(JodaBeanUtils.toString(effectiveDateOffset)).append(',').append(' ');
+      buf.append("maturityDateOffset").append('=').append(JodaBeanUtils.toString(maturityDateOffset)).append(',').append(' ');
+      buf.append("dayCount").append('=').append(JodaBeanUtils.toString(dayCount));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/basics/src/main/java/com/opengamma/basics/index/OvernightIndex.java
+++ b/basics/src/main/java/com/opengamma/basics/index/OvernightIndex.java
@@ -1,0 +1,763 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Set;
+
+import org.joda.beans.Bean;
+import org.joda.beans.BeanDefinition;
+import org.joda.beans.ImmutableBean;
+import org.joda.beans.JodaBeanUtils;
+import org.joda.beans.MetaProperty;
+import org.joda.beans.Property;
+import org.joda.beans.PropertyDefinition;
+import org.joda.beans.impl.direct.DirectFieldsBeanBuilder;
+import org.joda.beans.impl.direct.DirectMetaBean;
+import org.joda.beans.impl.direct.DirectMetaProperty;
+import org.joda.beans.impl.direct.DirectMetaPropertyMap;
+import org.joda.convert.FromString;
+
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.date.DayCount;
+import com.opengamma.basics.date.HolidayCalendar;
+import com.opengamma.basics.date.Tenor;
+import com.opengamma.collect.ArgChecker;
+
+/**
+ * An overnight index, such as Sonia or Eonia.
+ * <p>
+ * An index represented by this class relates to lending over one night.
+ * The rate typically refers to "Today/Tomorrow" but might refer to "Tomorrow/Next".
+ * <p>
+ * The index is defined by four dates.
+ * The fixing date is the date on which the index is to be observed.
+ * The publication date is the date on which the fixed rate is actually published.
+ * The effective date is the date on which the implied deposit starts.
+ * The maturity date is the date on which the implied deposit ends.
+ */
+@BeanDefinition(cacheHashCode = true)
+public final class OvernightIndex
+    implements RateIndex, ImmutableBean, Serializable {
+
+  /**
+   * Serialization version.
+   */
+  private static final long serialVersionUID = 1;
+
+  /**
+   * The currency of the index.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final Currency currency;
+  /**
+   * The index name, such as 'GBP-SONIA'.
+   */
+  @PropertyDefinition(validate = "notEmpty", overrideGet = true)
+  private final String name;
+  /**
+   * The calendar that the index uses.
+   * <p>
+   * All dates are calculated with reference to the same calendar.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final HolidayCalendar calendar;
+  /**
+   * The number of days to add to the fixing date to obtain the publication date.
+   * <p>
+   * In most cases, the fixing rate is available on the fixing date.
+   * In a few cases, publication of the fixing rate is delayed until the following business day.
+   * This property is zero if publication is on the fixing date, or one if it is the next day.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final int publicationDateOffset;
+  /**
+   * The number of days to add to the fixing date to obtain the effective date.
+   * <p>
+   * In most cases, the settlement date and start of the implied deposit is on the fixing date.
+   * In a few cases, the settlement date is the following business day.
+   * This property is zero if settlement is on the fixing date, or one if it is the next day.
+   * Maturity is always one business day after the settlement date.
+   */
+  @PropertyDefinition(validate = "notNull")
+  private final int effectiveDateOffset;
+  /**
+   * The day count convention.
+   */
+  @PropertyDefinition(validate = "notNull", overrideGet = true)
+  private final DayCount dayCount;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains an {@code OvernightIndex} from a unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the index
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static OvernightIndex of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return RateIndices.ENUM_LOOKUP.lookup(uniqueName, OvernightIndex.class);
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Returns the name of the index.
+   * 
+   * @return the name of the index
+   */
+  @Override
+  public String toString() {
+    return getName();
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the type of the index, which is tenor.
+   * 
+   * @return the index type
+   */
+  @Override
+  public RateIndexType getType() {
+    return RateIndexType.OVERNIGHT;
+  }
+
+  /**
+   * Gets the tenor of the index, which is always one day.
+   * 
+   * @return the one day tenor
+   */
+  @Override
+  public Tenor getTenor() {
+    return Tenor.TENOR_1D;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the publication date from the fixing date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The publication date is the date on which the fixed rate is actually published.
+   * <p>
+   * An IBOR-like index is always published on the same day as the fixing date.
+   * <p>
+   * No error is thrown if the input date is not a valid fixing date.
+   * Instead, the fixing date is moved to the next business day and then processed.
+   * 
+   * @param fixingDate  the fixing date
+   * @return the publication date
+   */
+  @Override
+  public LocalDate calculatePublicationFromFixing(LocalDate fixingDate) {
+    ArgChecker.notNull(fixingDate, "fixingDate");
+    return calendar.shift(calendar.nextOrSame(fixingDate), publicationDateOffset);
+  }
+
+  /**
+   * Calculates the effective date from the fixing date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The effective date is the date on which the implied deposit starts.
+   * <p>
+   * No error is thrown if the input date is not a valid fixing date.
+   * Instead, the fixing date is moved to the next business day and then processed.
+   * 
+   * @param fixingDate  the fixing date
+   * @return the effective date
+   */
+  @Override
+  public LocalDate calculateEffectiveFromFixing(LocalDate fixingDate) {
+    ArgChecker.notNull(fixingDate, "fixingDate");
+    return calendar.shift(calendar.nextOrSame(fixingDate), effectiveDateOffset);
+  }
+
+  /**
+   * Calculates the fixing date from the effective date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The effective date is the date on which the implied deposit starts.
+   * <p>
+   * No error is thrown if the input date is not a valid effective date.
+   * Instead, the effective date is moved to the next business day and then processed.
+   * 
+   * @param effectiveDate  the effective date
+   * @return the fixing date
+   */
+  @Override
+  public LocalDate calculateFixingFromEffective(LocalDate effectiveDate)  {
+    ArgChecker.notNull(effectiveDate, "effectiveDate");
+    return calendar.shift(calendar.nextOrSame(effectiveDate), -effectiveDateOffset);
+  }
+
+  /**
+   * Calculates the maturity date from the effective date.
+   * <p>
+   * The effective date is the date on which the implied deposit starts.
+   * The maturity date is the date on which the implied deposit ends.
+   * <p>
+   * No error is thrown if the input date is not a valid effective date.
+   * Instead, the effective date is moved to the next business day and then processed.
+   * 
+   * @param effectiveDate  the effective date
+   * @return the maturity date
+   */
+  @Override
+  public LocalDate calculateMaturityFromEffective(LocalDate effectiveDate) {
+    ArgChecker.notNull(effectiveDate, "effectiveDate");
+    return calendar.shift(calendar.nextOrSame(effectiveDate), 1);
+  }
+
+  //------------------------- AUTOGENERATED START -------------------------
+  ///CLOVER:OFF
+  /**
+   * The meta-bean for {@code OvernightIndex}.
+   * @return the meta-bean, not null
+   */
+  public static OvernightIndex.Meta meta() {
+    return OvernightIndex.Meta.INSTANCE;
+  }
+
+  static {
+    JodaBeanUtils.registerMetaBean(OvernightIndex.Meta.INSTANCE);
+  }
+
+  /**
+   * The cached hash code, using the racy single-check idiom.
+   */
+  private int cachedHashCode;
+
+  /**
+   * Returns a builder used to create an instance of the bean.
+   * @return the builder, not null
+   */
+  public static OvernightIndex.Builder builder() {
+    return new OvernightIndex.Builder();
+  }
+
+  private OvernightIndex(
+      Currency currency,
+      String name,
+      HolidayCalendar calendar,
+      int publicationDateOffset,
+      int effectiveDateOffset,
+      DayCount dayCount) {
+    JodaBeanUtils.notNull(currency, "currency");
+    JodaBeanUtils.notEmpty(name, "name");
+    JodaBeanUtils.notNull(calendar, "calendar");
+    JodaBeanUtils.notNull(publicationDateOffset, "publicationDateOffset");
+    JodaBeanUtils.notNull(effectiveDateOffset, "effectiveDateOffset");
+    JodaBeanUtils.notNull(dayCount, "dayCount");
+    this.currency = currency;
+    this.name = name;
+    this.calendar = calendar;
+    this.publicationDateOffset = publicationDateOffset;
+    this.effectiveDateOffset = effectiveDateOffset;
+    this.dayCount = dayCount;
+  }
+
+  @Override
+  public OvernightIndex.Meta metaBean() {
+    return OvernightIndex.Meta.INSTANCE;
+  }
+
+  @Override
+  public <R> Property<R> property(String propertyName) {
+    return metaBean().<R>metaProperty(propertyName).createProperty(this);
+  }
+
+  @Override
+  public Set<String> propertyNames() {
+    return metaBean().metaPropertyMap().keySet();
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the currency of the index.
+   * @return the value of the property, not null
+   */
+  @Override
+  public Currency getCurrency() {
+    return currency;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the index name, such as 'GBP-SONIA'.
+   * @return the value of the property, not empty
+   */
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the calendar that the index uses.
+   * <p>
+   * All dates are calculated with reference to the same calendar.
+   * @return the value of the property, not null
+   */
+  public HolidayCalendar getCalendar() {
+    return calendar;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the number of days to add to the fixing date to obtain the publication date.
+   * <p>
+   * In most cases, the fixing rate is available on the fixing date.
+   * In a few cases, publication of the fixing rate is delayed until the following business day.
+   * This property is zero if publication is on the fixing date, or one if it is the next day.
+   * @return the value of the property, not null
+   */
+  public int getPublicationDateOffset() {
+    return publicationDateOffset;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the number of days to add to the fixing date to obtain the effective date.
+   * <p>
+   * In most cases, the settlement date and start of the implied deposit is on the fixing date.
+   * In a few cases, the settlement date is the following business day.
+   * This property is zero if settlement is on the fixing date, or one if it is the next day.
+   * Maturity is always one business day after the settlement date.
+   * @return the value of the property, not null
+   */
+  public int getEffectiveDateOffset() {
+    return effectiveDateOffset;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Gets the day count convention.
+   * @return the value of the property, not null
+   */
+  @Override
+  public DayCount getDayCount() {
+    return dayCount;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * Returns a builder that allows this bean to be mutated.
+   * @return the mutable builder, not null
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (obj == this) {
+      return true;
+    }
+    if (obj != null && obj.getClass() == this.getClass()) {
+      OvernightIndex other = (OvernightIndex) obj;
+      return JodaBeanUtils.equal(getCurrency(), other.getCurrency()) &&
+          JodaBeanUtils.equal(getName(), other.getName()) &&
+          JodaBeanUtils.equal(getCalendar(), other.getCalendar()) &&
+          (getPublicationDateOffset() == other.getPublicationDateOffset()) &&
+          (getEffectiveDateOffset() == other.getEffectiveDateOffset()) &&
+          JodaBeanUtils.equal(getDayCount(), other.getDayCount());
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hash = cachedHashCode;
+    if (hash == 0) {
+      hash = getClass().hashCode();
+      hash += hash * 31 + JodaBeanUtils.hashCode(getCurrency());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getName());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getCalendar());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getPublicationDateOffset());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getEffectiveDateOffset());
+      hash += hash * 31 + JodaBeanUtils.hashCode(getDayCount());
+      cachedHashCode = hash;
+    }
+    return hash;
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The meta-bean for {@code OvernightIndex}.
+   */
+  public static final class Meta extends DirectMetaBean {
+    /**
+     * The singleton instance of the meta-bean.
+     */
+    static final Meta INSTANCE = new Meta();
+
+    /**
+     * The meta-property for the {@code currency} property.
+     */
+    private final MetaProperty<Currency> currency = DirectMetaProperty.ofImmutable(
+        this, "currency", OvernightIndex.class, Currency.class);
+    /**
+     * The meta-property for the {@code name} property.
+     */
+    private final MetaProperty<String> name = DirectMetaProperty.ofImmutable(
+        this, "name", OvernightIndex.class, String.class);
+    /**
+     * The meta-property for the {@code calendar} property.
+     */
+    private final MetaProperty<HolidayCalendar> calendar = DirectMetaProperty.ofImmutable(
+        this, "calendar", OvernightIndex.class, HolidayCalendar.class);
+    /**
+     * The meta-property for the {@code publicationDateOffset} property.
+     */
+    private final MetaProperty<Integer> publicationDateOffset = DirectMetaProperty.ofImmutable(
+        this, "publicationDateOffset", OvernightIndex.class, Integer.TYPE);
+    /**
+     * The meta-property for the {@code effectiveDateOffset} property.
+     */
+    private final MetaProperty<Integer> effectiveDateOffset = DirectMetaProperty.ofImmutable(
+        this, "effectiveDateOffset", OvernightIndex.class, Integer.TYPE);
+    /**
+     * The meta-property for the {@code dayCount} property.
+     */
+    private final MetaProperty<DayCount> dayCount = DirectMetaProperty.ofImmutable(
+        this, "dayCount", OvernightIndex.class, DayCount.class);
+    /**
+     * The meta-properties.
+     */
+    private final Map<String, MetaProperty<?>> metaPropertyMap$ = new DirectMetaPropertyMap(
+        this, null,
+        "currency",
+        "name",
+        "calendar",
+        "publicationDateOffset",
+        "effectiveDateOffset",
+        "dayCount");
+
+    /**
+     * Restricted constructor.
+     */
+    private Meta() {
+    }
+
+    @Override
+    protected MetaProperty<?> metaPropertyGet(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          return currency;
+        case 3373707:  // name
+          return name;
+        case -178324674:  // calendar
+          return calendar;
+        case 1901198637:  // publicationDateOffset
+          return publicationDateOffset;
+        case 1571923688:  // effectiveDateOffset
+          return effectiveDateOffset;
+        case 1905311443:  // dayCount
+          return dayCount;
+      }
+      return super.metaPropertyGet(propertyName);
+    }
+
+    @Override
+    public OvernightIndex.Builder builder() {
+      return new OvernightIndex.Builder();
+    }
+
+    @Override
+    public Class<? extends OvernightIndex> beanType() {
+      return OvernightIndex.class;
+    }
+
+    @Override
+    public Map<String, MetaProperty<?>> metaPropertyMap() {
+      return metaPropertyMap$;
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * The meta-property for the {@code currency} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Currency> currency() {
+      return currency;
+    }
+
+    /**
+     * The meta-property for the {@code name} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<String> name() {
+      return name;
+    }
+
+    /**
+     * The meta-property for the {@code calendar} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<HolidayCalendar> calendar() {
+      return calendar;
+    }
+
+    /**
+     * The meta-property for the {@code publicationDateOffset} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Integer> publicationDateOffset() {
+      return publicationDateOffset;
+    }
+
+    /**
+     * The meta-property for the {@code effectiveDateOffset} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<Integer> effectiveDateOffset() {
+      return effectiveDateOffset;
+    }
+
+    /**
+     * The meta-property for the {@code dayCount} property.
+     * @return the meta-property, not null
+     */
+    public MetaProperty<DayCount> dayCount() {
+      return dayCount;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    protected Object propertyGet(Bean bean, String propertyName, boolean quiet) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          return ((OvernightIndex) bean).getCurrency();
+        case 3373707:  // name
+          return ((OvernightIndex) bean).getName();
+        case -178324674:  // calendar
+          return ((OvernightIndex) bean).getCalendar();
+        case 1901198637:  // publicationDateOffset
+          return ((OvernightIndex) bean).getPublicationDateOffset();
+        case 1571923688:  // effectiveDateOffset
+          return ((OvernightIndex) bean).getEffectiveDateOffset();
+        case 1905311443:  // dayCount
+          return ((OvernightIndex) bean).getDayCount();
+      }
+      return super.propertyGet(bean, propertyName, quiet);
+    }
+
+    @Override
+    protected void propertySet(Bean bean, String propertyName, Object newValue, boolean quiet) {
+      metaProperty(propertyName);
+      if (quiet) {
+        return;
+      }
+      throw new UnsupportedOperationException("Property cannot be written: " + propertyName);
+    }
+
+  }
+
+  //-----------------------------------------------------------------------
+  /**
+   * The bean-builder for {@code OvernightIndex}.
+   */
+  public static final class Builder extends DirectFieldsBeanBuilder<OvernightIndex> {
+
+    private Currency currency;
+    private String name;
+    private HolidayCalendar calendar;
+    private int publicationDateOffset;
+    private int effectiveDateOffset;
+    private DayCount dayCount;
+
+    /**
+     * Restricted constructor.
+     */
+    private Builder() {
+    }
+
+    /**
+     * Restricted copy constructor.
+     * @param beanToCopy  the bean to copy from, not null
+     */
+    private Builder(OvernightIndex beanToCopy) {
+      this.currency = beanToCopy.getCurrency();
+      this.name = beanToCopy.getName();
+      this.calendar = beanToCopy.getCalendar();
+      this.publicationDateOffset = beanToCopy.getPublicationDateOffset();
+      this.effectiveDateOffset = beanToCopy.getEffectiveDateOffset();
+      this.dayCount = beanToCopy.getDayCount();
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public Object get(String propertyName) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          return currency;
+        case 3373707:  // name
+          return name;
+        case -178324674:  // calendar
+          return calendar;
+        case 1901198637:  // publicationDateOffset
+          return publicationDateOffset;
+        case 1571923688:  // effectiveDateOffset
+          return effectiveDateOffset;
+        case 1905311443:  // dayCount
+          return dayCount;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+    }
+
+    @Override
+    public Builder set(String propertyName, Object newValue) {
+      switch (propertyName.hashCode()) {
+        case 575402001:  // currency
+          this.currency = (Currency) newValue;
+          break;
+        case 3373707:  // name
+          this.name = (String) newValue;
+          break;
+        case -178324674:  // calendar
+          this.calendar = (HolidayCalendar) newValue;
+          break;
+        case 1901198637:  // publicationDateOffset
+          this.publicationDateOffset = (Integer) newValue;
+          break;
+        case 1571923688:  // effectiveDateOffset
+          this.effectiveDateOffset = (Integer) newValue;
+          break;
+        case 1905311443:  // dayCount
+          this.dayCount = (DayCount) newValue;
+          break;
+        default:
+          throw new NoSuchElementException("Unknown property: " + propertyName);
+      }
+      return this;
+    }
+
+    @Override
+    public Builder set(MetaProperty<?> property, Object value) {
+      super.set(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(String propertyName, String value) {
+      setString(meta().metaProperty(propertyName), value);
+      return this;
+    }
+
+    @Override
+    public Builder setString(MetaProperty<?> property, String value) {
+      super.setString(property, value);
+      return this;
+    }
+
+    @Override
+    public Builder setAll(Map<String, ? extends Object> propertyValueMap) {
+      super.setAll(propertyValueMap);
+      return this;
+    }
+
+    @Override
+    public OvernightIndex build() {
+      return new OvernightIndex(
+          currency,
+          name,
+          calendar,
+          publicationDateOffset,
+          effectiveDateOffset,
+          dayCount);
+    }
+
+    //-----------------------------------------------------------------------
+    /**
+     * Sets the {@code currency} property in the builder.
+     * @param currency  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder currency(Currency currency) {
+      JodaBeanUtils.notNull(currency, "currency");
+      this.currency = currency;
+      return this;
+    }
+
+    /**
+     * Sets the {@code name} property in the builder.
+     * @param name  the new value, not empty
+     * @return this, for chaining, not null
+     */
+    public Builder name(String name) {
+      JodaBeanUtils.notEmpty(name, "name");
+      this.name = name;
+      return this;
+    }
+
+    /**
+     * Sets the {@code calendar} property in the builder.
+     * @param calendar  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder calendar(HolidayCalendar calendar) {
+      JodaBeanUtils.notNull(calendar, "calendar");
+      this.calendar = calendar;
+      return this;
+    }
+
+    /**
+     * Sets the {@code publicationDateOffset} property in the builder.
+     * @param publicationDateOffset  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder publicationDateOffset(int publicationDateOffset) {
+      JodaBeanUtils.notNull(publicationDateOffset, "publicationDateOffset");
+      this.publicationDateOffset = publicationDateOffset;
+      return this;
+    }
+
+    /**
+     * Sets the {@code effectiveDateOffset} property in the builder.
+     * @param effectiveDateOffset  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder effectiveDateOffset(int effectiveDateOffset) {
+      JodaBeanUtils.notNull(effectiveDateOffset, "effectiveDateOffset");
+      this.effectiveDateOffset = effectiveDateOffset;
+      return this;
+    }
+
+    /**
+     * Sets the {@code dayCount} property in the builder.
+     * @param dayCount  the new value, not null
+     * @return this, for chaining, not null
+     */
+    public Builder dayCount(DayCount dayCount) {
+      JodaBeanUtils.notNull(dayCount, "dayCount");
+      this.dayCount = dayCount;
+      return this;
+    }
+
+    //-----------------------------------------------------------------------
+    @Override
+    public String toString() {
+      StringBuilder buf = new StringBuilder(224);
+      buf.append("OvernightIndex.Builder{");
+      buf.append("currency").append('=').append(JodaBeanUtils.toString(currency)).append(',').append(' ');
+      buf.append("name").append('=').append(JodaBeanUtils.toString(name)).append(',').append(' ');
+      buf.append("calendar").append('=').append(JodaBeanUtils.toString(calendar)).append(',').append(' ');
+      buf.append("publicationDateOffset").append('=').append(JodaBeanUtils.toString(publicationDateOffset)).append(',').append(' ');
+      buf.append("effectiveDateOffset").append('=').append(JodaBeanUtils.toString(effectiveDateOffset)).append(',').append(' ');
+      buf.append("dayCount").append('=').append(JodaBeanUtils.toString(dayCount));
+      buf.append('}');
+      return buf.toString();
+    }
+
+  }
+
+  ///CLOVER:ON
+  //-------------------------- AUTOGENERATED END --------------------------
+}

--- a/basics/src/main/java/com/opengamma/basics/index/RateIndex.java
+++ b/basics/src/main/java/com/opengamma/basics/index/RateIndex.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import java.time.LocalDate;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.date.DayCount;
+import com.opengamma.basics.date.Tenor;
+import com.opengamma.collect.ArgChecker;
+import com.opengamma.collect.named.ExtendedEnum;
+import com.opengamma.collect.named.Named;
+
+/**
+ * A index of interest rates, such as an Overnight or Inter-Bank rate.
+ * <p>
+ * Many financial products require knowledge of such as Libor.
+ * Implementations of this interface define these rates.
+ * <p>
+ * The index is defined by four dates.
+ * The fixing date is the date on which the index is to be observed.
+ * The publication date is the date on which the fixed rate is actually published.
+ * The effective date is the date on which the implied deposit starts.
+ * The maturity date is the date on which the implied deposit ends.
+ * <p>
+ * The most common implementations are provided in {@link RateIndices}.
+ * <p>
+ * All implementations of this interface must be immutable and thread-safe.
+ */
+public interface RateIndex
+    extends Named {
+
+  /**
+   * Obtains a {@code RateIndex} from a unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the rate index
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static RateIndex of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return extendedEnum().lookup(uniqueName);
+  }
+
+  /**
+   * Gets the extended enum helper.
+   * <p>
+   * This helper allows instances of {@code RateIndex} to be lookup up.
+   * It also provides the complete set of available instances.
+   * 
+   * @return the extended enum helper
+   */
+  public static ExtendedEnum<RateIndex> extendedEnum() {
+    return RateIndices.ENUM_LOOKUP;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the type of the index.
+   * 
+   * @return the type of the index
+   */
+  public abstract RateIndexType getType();
+
+  /**
+   * Gets the currency of the index.
+   * 
+   * @return the currency of the index
+   */
+  public abstract Currency getCurrency();
+
+  /**
+   * Gets the tenor of the index.
+   * 
+   * @return the tenor
+   */
+  public Tenor getTenor();
+
+  /**
+   * Gets the day count convention of the index.
+   * 
+   * @return the day count convention
+   */
+  public DayCount getDayCount();
+
+  //-------------------------------------------------------------------------
+  /**
+   * Calculates the publication date from the fixing date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The publication date is the date on which the fixed rate is actually published.
+   * <p>
+   * In most cases, the rate is published on the fixing date.
+   * A few indices, such as the US Fed Fund, publish the rate on the following business day.
+   * <p>
+   * No error is thrown if the input date is not a valid fixing date.
+   * Instead, the fixing date is moved to the next business day and then processed.
+   * 
+   * @param fixingDate  the fixing date
+   * @return the publication date
+   */
+  public LocalDate calculatePublicationFromFixing(LocalDate fixingDate);
+
+  /**
+   * Calculates the effective date from the fixing date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The effective date is the date on which the implied deposit starts.
+   * <p>
+   * For an overnight index, these two dates are typically the same.
+   * For an IBOR-like index, they typically differ by two business days.
+   * <p>
+   * No error is thrown if the input date is not a valid fixing date.
+   * Instead, the fixing date is moved to the next business day and then processed.
+   * 
+   * @param fixingDate  the fixing date
+   * @return the effective date
+   */
+  public LocalDate calculateEffectiveFromFixing(LocalDate fixingDate);
+
+  /**
+   * Calculates the fixing date from the effective date.
+   * <p>
+   * The fixing date is the date on which the index is to be observed.
+   * The effective date is the date on which the implied deposit starts.
+   * <p>
+   * For an overnight index, these two dates are typically the same.
+   * For an IBOR-like index, they typically differ by two business days.
+   * <p>
+   * No error is thrown if the input date is not a valid effective date.
+   * Instead, the effective date is moved to the next business day and then processed.
+   * 
+   * @param effectiveDate  the effective date
+   * @return the fixing date
+   */
+  public LocalDate calculateFixingFromEffective(LocalDate effectiveDate);
+
+  /**
+   * Calculates the maturity date from the effective date.
+   * <p>
+   * The effective date is the date on which the implied deposit starts.
+   * The maturity date is the date on which the implied deposit ends.
+   * <p>
+   * For an overnight index, these two dates are one day apart.
+   * For an IBOR-like index, they differ by the tenor.
+   * <p>
+   * No error is thrown if the input date is not a valid effective date.
+   * Instead, the effective date is moved to the next business day and then processed.
+   * 
+   * @param effectiveDate  the effective date
+   * @return the maturity date
+   */
+  public LocalDate calculateMaturityFromEffective(LocalDate effectiveDate);
+
+  //-------------------------------------------------------------------------
+  /**
+   * Gets the name that uniquely identifies this index.
+   * <p>
+   * This name is used in serialization and can be parsed using {@link #of(String)}.
+   * 
+   * @return the unique name
+   */
+  @ToString
+  @Override
+  public String getName();
+
+}

--- a/basics/src/main/java/com/opengamma/basics/index/RateIndexType.java
+++ b/basics/src/main/java/com/opengamma/basics/index/RateIndexType.java
@@ -1,0 +1,60 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import org.joda.convert.FromString;
+import org.joda.convert.ToString;
+
+import com.google.common.base.CaseFormat;
+import com.opengamma.collect.ArgChecker;
+
+/**
+ * The type of a rate index.
+ * <p>
+ * A rate index represents an agreed opinion on the rate for a certain type of deposit.
+ */
+public enum RateIndexType {
+
+  /**
+   * An index representing the interest rate for an overnight deposit.
+   * <p>
+   * This type includes indices that are strictly defined as "Tomorrow/Next" rather than "Overnight".
+   */
+  OVERNIGHT,
+  /**
+   * An index representing the interest rate for a deposit based on a tenor.
+   * <p>
+   * In many cases, there is a lag of 2 business days between the fixing date and the settlement date.
+   * The tenor of the deposit starts on the settlement date.
+   */
+  TENOR;
+
+  //-------------------------------------------------------------------------
+  /**
+   * Obtains the type from a unique name.
+   * 
+   * @param uniqueName  the unique name
+   * @return the type
+   * @throws IllegalArgumentException if the name is not known
+   */
+  @FromString
+  public static RateIndexType of(String uniqueName) {
+    ArgChecker.notNull(uniqueName, "uniqueName");
+    return valueOf(CaseFormat.UPPER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, uniqueName));
+  }
+
+  /**
+   * Returns the formatted unique name of the type.
+   * 
+   * @return the formatted string representing the type
+   */
+  @ToString
+  @Override
+  public String toString() {
+    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, name());
+  }
+
+}

--- a/basics/src/main/java/com/opengamma/basics/index/RateIndices.java
+++ b/basics/src/main/java/com/opengamma/basics/index/RateIndices.java
@@ -1,0 +1,377 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import com.opengamma.collect.named.ExtendedEnum;
+
+/**
+ * Constants and implementations for standard rate indices.
+ * <p>
+ * Each constant returns a standard definition of the specified index.
+ */
+public final class RateIndices {
+  // constants are indirected via ENUM_LOOKUP to allow them to be replaced by config
+
+  /**
+   * The extended enum lookup from name to instance.
+   */
+  static final ExtendedEnum<RateIndex> ENUM_LOOKUP = ExtendedEnum.of(RateIndex.class);
+
+  /**
+   * The SONIA index for GBP.
+   * <p>
+   * SONIA is an "Overnight" index.
+   */
+  public static final OvernightIndex GBP_SONIA = OvernightIndex.of(StandardOvernightIndices.GBP_SONIA.getName());
+  /**
+   * The TOIS index for CHF.
+   * <p>
+   * TOIS is a "Tomorrow/Next" index.
+   */
+  public static final OvernightIndex CHF_TOIS = OvernightIndex.of(StandardOvernightIndices.CHF_TOIS.getName());
+  /**
+   * The EONIA index for EUR.
+   * <p>
+   * EONIA is an "Overnight" index.
+   */
+  public static final OvernightIndex EUR_EONIA = OvernightIndex.of(StandardOvernightIndices.EUR_EONIA.getName());
+  /**
+   * The TONAR index for JPY.
+   * <p>
+   * TONAR is an "Overnight" index.
+   */
+  public static final OvernightIndex JPY_TONAR = OvernightIndex.of(StandardOvernightIndices.JPY_TONAR.getName());
+  /**
+   * The FED_FUND index for USD.
+   * <p>
+   * FED_FUND is an "Overnight" index.
+   */
+  public static final OvernightIndex USD_FED_FUND = OvernightIndex.of(StandardOvernightIndices.USD_FED_FUND.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week LIBOR index for GBP.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex GBP_LIBOR_1W = IborIndex.of(StandardIborIndices.GBP_LIBOR_1W.getName());
+  /**
+   * The 1 month LIBOR index for GBP.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex GBP_LIBOR_1M = IborIndex.of(StandardIborIndices.GBP_LIBOR_1M.getName());
+  /**
+   * The 2 month LIBOR index for GBP.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex GBP_LIBOR_2M = IborIndex.of(StandardIborIndices.GBP_LIBOR_2M.getName());
+  /**
+   * The 3 month LIBOR index for GBP.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex GBP_LIBOR_3M = IborIndex.of(StandardIborIndices.GBP_LIBOR_3M.getName());
+  /**
+   * The 6 month LIBOR index for GBP.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex GBP_LIBOR_6M = IborIndex.of(StandardIborIndices.GBP_LIBOR_6M.getName());
+  /**
+   * The 12 month LIBOR index for GBP.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex GBP_LIBOR_12M = IborIndex.of(StandardIborIndices.GBP_LIBOR_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week LIBOR index for CHF.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex CHF_LIBOR_1W = IborIndex.of(StandardIborIndices.CHF_LIBOR_1W.getName());
+  /**
+   * The 1 month LIBOR index for CHF.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex CHF_LIBOR_1M = IborIndex.of(StandardIborIndices.CHF_LIBOR_1M.getName());
+  /**
+   * The 2 month LIBOR index for CHF.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex CHF_LIBOR_2M = IborIndex.of(StandardIborIndices.CHF_LIBOR_2M.getName());
+  /**
+   * The 3 month LIBOR index for CHF.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex CHF_LIBOR_3M = IborIndex.of(StandardIborIndices.CHF_LIBOR_3M.getName());
+  /**
+   * The 6 month LIBOR index for CHF.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex CHF_LIBOR_6M = IborIndex.of(StandardIborIndices.CHF_LIBOR_6M.getName());
+  /**
+   * The 12 month LIBOR index for CHF.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex CHF_LIBOR_12M = IborIndex.of(StandardIborIndices.CHF_LIBOR_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week LIBOR index for EUR.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex EUR_LIBOR_1W = IborIndex.of(StandardIborIndices.EUR_LIBOR_1W.getName());
+  /**
+   * The 1 month LIBOR index for EUR.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex EUR_LIBOR_1M = IborIndex.of(StandardIborIndices.EUR_LIBOR_1M.getName());
+  /**
+   * The 2 month LIBOR index for EUR.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex EUR_LIBOR_2M = IborIndex.of(StandardIborIndices.EUR_LIBOR_2M.getName());
+  /**
+   * The 3 month LIBOR index for EUR.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex EUR_LIBOR_3M = IborIndex.of(StandardIborIndices.EUR_LIBOR_3M.getName());
+  /**
+   * The 6 month LIBOR index for EUR.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex EUR_LIBOR_6M = IborIndex.of(StandardIborIndices.EUR_LIBOR_6M.getName());
+  /**
+   * The 12 month LIBOR index for EUR.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex EUR_LIBOR_12M = IborIndex.of(StandardIborIndices.EUR_LIBOR_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week LIBOR index for JPY.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex JPY_LIBOR_1W = IborIndex.of(StandardIborIndices.JPY_LIBOR_1W.getName());
+  /**
+   * The 1 month LIBOR index for JPY.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex JPY_LIBOR_1M = IborIndex.of(StandardIborIndices.JPY_LIBOR_1M.getName());
+  /**
+   * The 2 month LIBOR index for JPY.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex JPY_LIBOR_2M = IborIndex.of(StandardIborIndices.JPY_LIBOR_2M.getName());
+  /**
+   * The 3 month LIBOR index for JPY.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex JPY_LIBOR_3M = IborIndex.of(StandardIborIndices.JPY_LIBOR_3M.getName());
+  /**
+   * The 6 month LIBOR index for JPY.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex JPY_LIBOR_6M = IborIndex.of(StandardIborIndices.JPY_LIBOR_6M.getName());
+  /**
+   * The 12 month LIBOR index for JPY.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex JPY_LIBOR_12M = IborIndex.of(StandardIborIndices.JPY_LIBOR_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week LIBOR index for USD.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex USD_LIBOR_1W = IborIndex.of(StandardIborIndices.USD_LIBOR_1W.getName());
+  /**
+   * The 1 month LIBOR index for USD.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex USD_LIBOR_1M = IborIndex.of(StandardIborIndices.USD_LIBOR_1M.getName());
+  /**
+   * The 2 month LIBOR index for USD.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex USD_LIBOR_2M = IborIndex.of(StandardIborIndices.USD_LIBOR_2M.getName());
+  /**
+   * The 3 month LIBOR index for USD.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex USD_LIBOR_3M = IborIndex.of(StandardIborIndices.USD_LIBOR_3M.getName());
+  /**
+   * The 6 month LIBOR index for USD.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex USD_LIBOR_6M = IborIndex.of(StandardIborIndices.USD_LIBOR_6M.getName());
+  /**
+   * The 12 month LIBOR index for USD.
+   * <p>
+   * The "London Interbank Offered Rate".
+   */
+  public static final IborIndex USD_LIBOR_12M = IborIndex.of(StandardIborIndices.USD_LIBOR_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_1W = IborIndex.of(StandardIborIndices.EURIBOR_1W.getName());
+  /**
+   * The 2 week EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_2W = IborIndex.of(StandardIborIndices.EURIBOR_2W.getName());
+  /**
+   * The 1 month EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_1M = IborIndex.of(StandardIborIndices.EURIBOR_1M.getName());
+  /**
+   * The 2 month EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_2M = IborIndex.of(StandardIborIndices.EURIBOR_2M.getName());
+  /**
+   * The 3 month EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_3M = IborIndex.of(StandardIborIndices.EURIBOR_3M.getName());
+  /**
+   * The 6 month EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_6M = IborIndex.of(StandardIborIndices.EURIBOR_6M.getName());
+  /**
+   * The 9 month EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_9M = IborIndex.of(StandardIborIndices.EURIBOR_9M.getName());
+  /**
+   * The 12 month EURIBOR index.
+   * <p>
+   * The "Euro Interbank Offered Rate".
+   */
+  public static final IborIndex EURIBOR_12M = IborIndex.of(StandardIborIndices.EURIBOR_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week TIBOR (Japan) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", unsecured call market.
+   */
+  public static final IborIndex JPY_TIBOR_JAPAN_1W = IborIndex.of(StandardIborIndices.JPY_TIBOR_JAPAN_1W.getName());
+  /**
+   * The 1 month TIBOR (Japan) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", unsecured call market.
+   */
+  public static final IborIndex JPY_TIBOR_JAPAN_1M = IborIndex.of(StandardIborIndices.JPY_TIBOR_JAPAN_1M.getName());
+  /**
+   * The 2 month TIBOR (Japan) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", unsecured call market.
+   */
+  public static final IborIndex JPY_TIBOR_JAPAN_2M = IborIndex.of(StandardIborIndices.JPY_TIBOR_JAPAN_2M.getName());
+  /**
+   * The 3 month TIBOR (Japan) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", unsecured call market.
+   */
+  public static final IborIndex JPY_TIBOR_JAPAN_3M = IborIndex.of(StandardIborIndices.JPY_TIBOR_JAPAN_3M.getName());
+  /**
+   * The 6 month TIBOR (Japan) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", unsecured call market.
+   */
+  public static final IborIndex JPY_TIBOR_JAPAN_6M = IborIndex.of(StandardIborIndices.JPY_TIBOR_JAPAN_6M.getName());
+  /**
+   * The 12 month TIBOR (Japan) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", unsecured call market.
+   */
+  public static final IborIndex JPY_TIBOR_JAPAN_12M = IborIndex.of(StandardIborIndices.JPY_TIBOR_JAPAN_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * The 1 week TIBOR (Euroyen) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", Japan offshore market.
+   */
+  public static final IborIndex JPY_TIBOR_EUROYEN_1W = IborIndex.of(StandardIborIndices.JPY_TIBOR_EUROYEN_1W.getName());
+  /**
+   * The 1 month TIBOR (Euroyen) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", Japan offshore market.
+   */
+  public static final IborIndex JPY_TIBOR_EUROYEN_1M = IborIndex.of(StandardIborIndices.JPY_TIBOR_EUROYEN_1M.getName());
+  /**
+   * The 2 month TIBOR (Euroyen) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", Japan offshore market.
+   */
+  public static final IborIndex JPY_TIBOR_EUROYEN_2M = IborIndex.of(StandardIborIndices.JPY_TIBOR_EUROYEN_2M.getName());
+  /**
+   * The 3 month TIBOR (Euroyen) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", Japan offshore market.
+   */
+  public static final IborIndex JPY_TIBOR_EUROYEN_3M = IborIndex.of(StandardIborIndices.JPY_TIBOR_EUROYEN_3M.getName());
+  /**
+   * The 6 month TIBOR (Euroyen) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", Japan offshore market.
+   */
+  public static final IborIndex JPY_TIBOR_EUROYEN_6M = IborIndex.of(StandardIborIndices.JPY_TIBOR_EUROYEN_6M.getName());
+  /**
+   * The 12 month TIBOR (Euroyen) index.
+   * <p>
+   * The "Tokyo Interbank Offered Rate", Japan offshore market.
+   */
+  public static final IborIndex JPY_TIBOR_EUROYEN_12M = IborIndex.of(StandardIborIndices.JPY_TIBOR_EUROYEN_12M.getName());
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private RateIndices() {
+  }
+
+}

--- a/basics/src/main/java/com/opengamma/basics/index/StandardIborIndices.java
+++ b/basics/src/main/java/com/opengamma/basics/index/StandardIborIndices.java
@@ -1,0 +1,250 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import static com.opengamma.basics.currency.Currency.CHF;
+import static com.opengamma.basics.currency.Currency.EUR;
+import static com.opengamma.basics.currency.Currency.GBP;
+import static com.opengamma.basics.currency.Currency.JPY;
+import static com.opengamma.basics.currency.Currency.USD;
+import static com.opengamma.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
+import static com.opengamma.basics.date.DayCounts.ACT_360;
+import static com.opengamma.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.basics.date.HolidayCalendars.CHZU;
+import static com.opengamma.basics.date.HolidayCalendars.EUTA;
+import static com.opengamma.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.basics.date.HolidayCalendars.JPTO;
+import static com.opengamma.basics.date.HolidayCalendars.USNY;
+import static com.opengamma.basics.date.Tenor.TENOR_12M;
+import static com.opengamma.basics.date.Tenor.TENOR_1M;
+import static com.opengamma.basics.date.Tenor.TENOR_1W;
+import static com.opengamma.basics.date.Tenor.TENOR_2M;
+import static com.opengamma.basics.date.Tenor.TENOR_2W;
+import static com.opengamma.basics.date.Tenor.TENOR_3M;
+import static com.opengamma.basics.date.Tenor.TENOR_6M;
+import static com.opengamma.basics.date.Tenor.TENOR_9M;
+
+import com.opengamma.basics.date.BusinessDayAdjustment;
+import com.opengamma.basics.date.DaysAdjustment;
+import com.opengamma.basics.date.HolidayCalendar;
+import com.opengamma.basics.date.PeriodAdditionConventions;
+import com.opengamma.basics.date.Tenor;
+import com.opengamma.basics.date.TenorAdjustment;
+
+/**
+ * Standard IBOR index implementations.
+ * <p>
+ * See {@link RateIndices} for the description of each.
+ */
+final class StandardIborIndices {
+  // http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
+  // LIBOR - http://www.bbalibor.com/technical-aspects/fixing-value-and-maturity
+  // different rules for overnight
+  // EURIBOR - http://www.bbalibor.com/technical-aspects/fixing-value-and-maturity
+  // EURIBOR - http://www.emmi-benchmarks.eu/assets/files/Euribor_code_conduct.pdf
+  // TIBOR - http://www.jbatibor.or.jp/english/public/
+
+  // GBP libor
+  public static final IborIndex GBP_LIBOR_1W = gbpLibor(TENOR_1W);
+  public static final IborIndex GBP_LIBOR_1M = gbpLibor(TENOR_1M);
+  public static final IborIndex GBP_LIBOR_2M = gbpLibor(TENOR_2M);
+  public static final IborIndex GBP_LIBOR_3M = gbpLibor(TENOR_3M);
+  public static final IborIndex GBP_LIBOR_6M = gbpLibor(TENOR_6M);
+  public static final IborIndex GBP_LIBOR_12M = gbpLibor(TENOR_12M);
+
+  // conventions for GBP libor
+  // settlement date equals fixing date
+  // maturity date last business day rule, modified following, GBLO
+  private static IborIndex gbpLibor(Tenor tenor) {
+    return IborIndex.builder()
+        .name("GBP-LIBOR-" + tenor)
+        .currency(GBP)
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.NONE)
+        .maturityDateOffset(maturity(tenor, GBLO))
+        .dayCount(ACT_365F)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // CHF libor
+  public static final IborIndex CHF_LIBOR_1W = chfLibor(TENOR_1W);
+  public static final IborIndex CHF_LIBOR_1M = chfLibor(TENOR_1M);
+  public static final IborIndex CHF_LIBOR_2M = chfLibor(TENOR_2M);
+  public static final IborIndex CHF_LIBOR_3M = chfLibor(TENOR_3M);
+  public static final IborIndex CHF_LIBOR_6M = chfLibor(TENOR_6M);
+  public static final IborIndex CHF_LIBOR_12M = chfLibor(TENOR_12M);
+
+  // conventions for CHF libor
+  // settlement date two GBLO business days after fixing date, adjusted to GBLO+CHZU
+  // maturity date last business day rule, modified following, GBLO+CHZU
+  private static IborIndex chfLibor(Tenor tenor) {
+    HolidayCalendar cal = GBLO.combineWith(CHZU);
+    return IborIndex.builder()
+        .name("CHF-LIBOR-" + tenor)
+        .currency(CHF)
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO, BusinessDayAdjustment.of(FOLLOWING, cal)))
+        .maturityDateOffset(maturity(tenor, cal))
+        .dayCount(ACT_360)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // EUR libor
+  public static final IborIndex EUR_LIBOR_1W = eurLibor(TENOR_1W);
+  public static final IborIndex EUR_LIBOR_1M = eurLibor(TENOR_1M);
+  public static final IborIndex EUR_LIBOR_2M = eurLibor(TENOR_2M);
+  public static final IborIndex EUR_LIBOR_3M = eurLibor(TENOR_3M);
+  public static final IborIndex EUR_LIBOR_6M = eurLibor(TENOR_6M);
+  public static final IborIndex EUR_LIBOR_12M = eurLibor(TENOR_12M);
+
+  // conventions for EUR libor
+  // settlement date two EUTA business days after fixing date
+  // maturity date last business day rule, modified following, EUTA
+  private static IborIndex eurLibor(Tenor tenor) {
+    return IborIndex.builder()
+        .name("EUR-LIBOR-" + tenor)
+        .currency(EUR)
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, EUTA))
+        .maturityDateOffset(maturity(tenor, EUTA))
+        .dayCount(ACT_360)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // JPY libor
+  public static final IborIndex JPY_LIBOR_1W = jpyLibor(TENOR_1W);
+  public static final IborIndex JPY_LIBOR_1M = jpyLibor(TENOR_1M);
+  public static final IborIndex JPY_LIBOR_2M = jpyLibor(TENOR_2M);
+  public static final IborIndex JPY_LIBOR_3M = jpyLibor(TENOR_3M);
+  public static final IborIndex JPY_LIBOR_6M = jpyLibor(TENOR_6M);
+  public static final IborIndex JPY_LIBOR_12M = jpyLibor(TENOR_12M);
+
+  // conventions for JPY libor
+  // settlement date two GBLO business days after fixing date, adjusted to GBLO+JPTO
+  // maturity date last business day rule, modified following, GBLO+JPTO
+  private static IborIndex jpyLibor(Tenor tenor) {
+    HolidayCalendar cal = GBLO.combineWith(JPTO);
+    return IborIndex.builder()
+        .name("JPY-LIBOR-" + tenor)
+        .currency(JPY)
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO, BusinessDayAdjustment.of(FOLLOWING, cal)))
+        .maturityDateOffset(maturity(tenor, cal))
+        .dayCount(ACT_360)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // USD libor
+  public static final IborIndex USD_LIBOR_1W = usdLibor(TENOR_1W);
+  public static final IborIndex USD_LIBOR_1M = usdLibor(TENOR_1M);
+  public static final IborIndex USD_LIBOR_2M = usdLibor(TENOR_2M);
+  public static final IborIndex USD_LIBOR_3M = usdLibor(TENOR_3M);
+  public static final IborIndex USD_LIBOR_6M = usdLibor(TENOR_6M);
+  public static final IborIndex USD_LIBOR_12M = usdLibor(TENOR_12M);
+
+  // conventions for USD libor
+  // settlement date two GBLO business days after fixing date, adjusted to GBLO+USNY
+  // maturity date last business day rule, modified following, GBLO+USNY
+  private static IborIndex usdLibor(Tenor tenor) {
+    HolidayCalendar cal = GBLO.combineWith(USNY);
+    return IborIndex.builder()
+        .name("USD-LIBOR-" + tenor)
+        .currency(USD)
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO, BusinessDayAdjustment.of(FOLLOWING, cal)))
+        .maturityDateOffset(maturity(tenor, cal))
+        .dayCount(ACT_360)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // Euribor
+  public static final IborIndex EURIBOR_1W = euribor(TENOR_1W);
+  public static final IborIndex EURIBOR_2W = euribor(TENOR_2W);
+  public static final IborIndex EURIBOR_1M = euribor(TENOR_1M);
+  public static final IborIndex EURIBOR_2M = euribor(TENOR_2M);
+  public static final IborIndex EURIBOR_3M = euribor(TENOR_3M);
+  public static final IborIndex EURIBOR_6M = euribor(TENOR_6M);
+  public static final IborIndex EURIBOR_9M = euribor(TENOR_9M);
+  public static final IborIndex EURIBOR_12M = euribor(TENOR_12M);
+
+  // conventions for euribor
+  private static IborIndex euribor(Tenor tenor) {
+    return IborIndex.builder()
+        .name("EURIBOR-" + tenor)
+        .currency(EUR)
+        .fixingCalendar(EUTA)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, EUTA))
+        .maturityDateOffset(maturity(tenor, EUTA))
+        .dayCount(ACT_360)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // JPY Tibor (Japan)
+  // only include some tenors here
+  public static final IborIndex JPY_TIBOR_JAPAN_1W = tiborJapan(TENOR_1W);
+  public static final IborIndex JPY_TIBOR_JAPAN_1M = tiborJapan(TENOR_1M);
+  public static final IborIndex JPY_TIBOR_JAPAN_2M = tiborJapan(TENOR_2M);
+  public static final IborIndex JPY_TIBOR_JAPAN_3M = tiborJapan(TENOR_3M);
+  public static final IborIndex JPY_TIBOR_JAPAN_6M = tiborJapan(TENOR_6M);
+  public static final IborIndex JPY_TIBOR_JAPAN_12M = tiborJapan(TENOR_12M);
+
+  // conventions for tibor
+  private static IborIndex tiborJapan(Tenor tenor) {
+    return IborIndex.builder()
+        .name("JPY-TIBOR-JAPAN-" + tenor)
+        .currency(JPY)
+        .fixingCalendar(JPTO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, JPTO))
+        .maturityDateOffset(maturity(tenor, JPTO))
+        .dayCount(ACT_365F)
+        .build();
+  }
+
+  //-------------------------------------------------------------------------
+  // JPY Tibor (Euroyen)
+  // only include some tenors here
+  public static final IborIndex JPY_TIBOR_EUROYEN_1W = tiborEuroyen(TENOR_1W);
+  public static final IborIndex JPY_TIBOR_EUROYEN_1M = tiborEuroyen(TENOR_1M);
+  public static final IborIndex JPY_TIBOR_EUROYEN_2M = tiborEuroyen(TENOR_2M);
+  public static final IborIndex JPY_TIBOR_EUROYEN_3M = tiborEuroyen(TENOR_3M);
+  public static final IborIndex JPY_TIBOR_EUROYEN_6M = tiborEuroyen(TENOR_6M);
+  public static final IborIndex JPY_TIBOR_EUROYEN_12M = tiborEuroyen(TENOR_12M);
+
+  // conventions for tibor
+  private static IborIndex tiborEuroyen(Tenor tenor) {
+    return IborIndex.builder()
+        .name("JPY-TIBOR-EUROYEN-" + tenor)
+        .currency(JPY)
+        .fixingCalendar(JPTO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, JPTO))
+        .maturityDateOffset(maturity(tenor, JPTO))
+        .dayCount(ACT_360)
+        .build();
+  }
+
+  // maturity rule for LIBOR
+  private static TenorAdjustment maturity(Tenor tenor, HolidayCalendar calendar) {
+    TenorAdjustment maturity = tenor.isMonthBased() ?
+        TenorAdjustment.ofLastBusinessDay(tenor, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, calendar)) :
+        TenorAdjustment.of(tenor, PeriodAdditionConventions.NONE, BusinessDayAdjustment.of(FOLLOWING, calendar));
+    return maturity;
+  }
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private StandardIborIndices() {
+  }
+
+}

--- a/basics/src/main/java/com/opengamma/basics/index/StandardOvernightIndices.java
+++ b/basics/src/main/java/com/opengamma/basics/index/StandardOvernightIndices.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import static com.opengamma.basics.currency.Currency.CHF;
+import static com.opengamma.basics.currency.Currency.EUR;
+import static com.opengamma.basics.currency.Currency.GBP;
+import static com.opengamma.basics.currency.Currency.JPY;
+import static com.opengamma.basics.currency.Currency.USD;
+import static com.opengamma.basics.date.DayCounts.ACT_360;
+import static com.opengamma.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.basics.date.HolidayCalendars.CHZU;
+import static com.opengamma.basics.date.HolidayCalendars.EUTA;
+import static com.opengamma.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.basics.date.HolidayCalendars.JPTO;
+import static com.opengamma.basics.date.HolidayCalendars.NYFD;
+
+/**
+ * Standard Overnight index implementations.
+ * <p>
+ * See {@link RateIndices} for the description of each.
+ */
+final class StandardOvernightIndices {
+  // http://www.opengamma.com/sites/default/files/interest-rate-instruments-and-market-conventions.pdf
+
+  // GBP SONIA
+  public static final OvernightIndex GBP_SONIA = OvernightIndex.builder()
+      .name("GBP-SONIA")
+      .currency(GBP)
+      .calendar(GBLO)
+      .publicationDateOffset(0)
+      .effectiveDateOffset(0)
+      .dayCount(ACT_365F)
+      .build();
+
+  // CHF TOIS
+  public static final OvernightIndex CHF_TOIS = OvernightIndex.builder()
+      .name("CHF-TOIS")
+      .currency(CHF)
+      .calendar(CHZU)
+      .publicationDateOffset(0)
+      .effectiveDateOffset(1)
+      .dayCount(ACT_360)
+      .build();
+
+  // EUR EONIA
+  public static final OvernightIndex EUR_EONIA = OvernightIndex.builder()
+      .name("EUR-EONIA")
+      .currency(EUR)
+      .calendar(EUTA)
+      .publicationDateOffset(0)
+      .effectiveDateOffset(0)
+      .dayCount(ACT_360)
+      .build();
+
+  // JPY TONAR
+  public static final OvernightIndex JPY_TONAR = OvernightIndex.builder()
+      .name("JPY-TONAR")
+      .currency(JPY)
+      .calendar(JPTO)
+      .publicationDateOffset(1)
+      .effectiveDateOffset(0)
+      .dayCount(ACT_365F)
+      .build();
+
+  // USD FedFund
+  public static final OvernightIndex USD_FED_FUND = OvernightIndex.builder()
+      .name("USD-FED-FUND")
+      .currency(USD)
+      .calendar(NYFD)
+      .publicationDateOffset(1)
+      .effectiveDateOffset(0)
+      .dayCount(ACT_360)
+      .build();
+
+  //-------------------------------------------------------------------------
+  /**
+   * Restricted constructor.
+   */
+  private StandardOvernightIndices() {
+  }
+
+}

--- a/basics/src/main/java/com/opengamma/basics/index/package-info.java
+++ b/basics/src/main/java/com/opengamma/basics/index/package-info.java
@@ -1,0 +1,11 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+
+/**
+ * Entity objects describing the indexes, such as LIBOR.
+ */
+@javax.annotation.ParametersAreNonnullByDefault
+package com.opengamma.basics.index;

--- a/basics/src/main/resources/com/opengamma/basics/index/RateIndex.properties
+++ b/basics/src/main/resources/com/opengamma/basics/index/RateIndex.properties
@@ -1,0 +1,21 @@
+# ExtendedEnum configuration
+
+# The priority value is used to select which file to process first
+# The highest numeric value has the highest priority
+priority = 0
+
+# The chain value is used to determine whether to chain on to the next lower priority file
+chain = false
+
+# The providers are the classes that define the enum
+# The key is always 'provider'
+# The value is of the form 'provider.full.class.name'
+# A provider class is one of the following
+# - a class implementing NamedLookup with a no-args constructor
+# - a class defining public static final constants
+provider = com.opengamma.basics.index.StandardIborIndices
+provider = com.opengamma.basics.index.StandardOvernightIndices
+
+# The set of alternate names
+# The key is always 'alternate'
+# The value is of the form 'alternateName -> standardName'

--- a/basics/src/test/java/com/opengamma/basics/index/IborIndexTest.java
+++ b/basics/src/test/java/com/opengamma/basics/index/IborIndexTest.java
@@ -1,0 +1,205 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import static com.opengamma.basics.currency.Currency.EUR;
+import static com.opengamma.basics.currency.Currency.GBP;
+import static com.opengamma.basics.currency.Currency.USD;
+import static com.opengamma.basics.date.BusinessDayConventions.FOLLOWING;
+import static com.opengamma.basics.date.BusinessDayConventions.MODIFIED_FOLLOWING;
+import static com.opengamma.basics.date.DayCounts.ACT_360;
+import static com.opengamma.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.basics.date.HolidayCalendars.EUTA;
+import static com.opengamma.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.basics.date.HolidayCalendars.USNY;
+import static com.opengamma.basics.date.Tenor.TENOR_3M;
+import static com.opengamma.basics.date.Tenor.TENOR_6M;
+import static com.opengamma.collect.TestHelper.assertJodaConvert;
+import static com.opengamma.collect.TestHelper.assertSerialization;
+import static com.opengamma.collect.TestHelper.assertThrows;
+import static com.opengamma.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.collect.TestHelper.coverPrivateConstructor;
+import static com.opengamma.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.basics.currency.Currency;
+import com.opengamma.basics.date.BusinessDayAdjustment;
+import com.opengamma.basics.date.DaysAdjustment;
+import com.opengamma.basics.date.TenorAdjustment;
+
+/**
+ * Test Ibor Index.
+ */
+@Test
+public class IborIndexTest {
+
+  public void test_null() {
+    IborIndex test = IborIndex.of("GBP-LIBOR-3M");
+    assertThrows(() -> test.calculatePublicationFromFixing(null), IllegalArgumentException.class);
+    assertThrows(() -> test.calculateEffectiveFromFixing(null), IllegalArgumentException.class);
+    assertThrows(() -> test.calculateFixingFromEffective(null), IllegalArgumentException.class);
+    assertThrows(() -> test.calculateMaturityFromEffective(null), IllegalArgumentException.class);
+  }
+
+  public void test_gbpLibor3m() {
+    IborIndex test = IborIndex.of("GBP-LIBOR-3M");
+    assertEquals(test.getType(), RateIndexType.TENOR);
+    assertEquals(test.getCurrency(), GBP);
+    assertEquals(test.getName(), "GBP-LIBOR-3M");
+    assertEquals(test.getTenor(), TENOR_3M);
+    assertEquals(test.getFixingCalendar(), GBLO);
+    assertEquals(test.getEffectiveDateOffset(), DaysAdjustment.NONE);
+    assertEquals(test.getMaturityDateOffset(),
+        TenorAdjustment.ofLastBusinessDay(TENOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO)));
+    assertEquals(test.getDayCount(), ACT_365F);
+    assertEquals(test.toString(), "GBP-LIBOR-3M");
+  }
+
+  public void test_gbpLibor3m_dates() {
+    IborIndex test = IborIndex.of("GBP-LIBOR-3M");
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 13)), date(2014, 10, 13));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 13)), date(2014, 10, 13));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 13)), date(2014, 10, 13));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 13)), date(2015, 1, 13));
+    // weekend
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 10)), date(2015, 1, 12));
+    // input date is Sunday
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 12)), date(2015, 1, 13));
+  }
+
+  public void test_usdLibor3m() {
+    IborIndex test = IborIndex.of("USD-LIBOR-3M");
+    assertEquals(test.getType(), RateIndexType.TENOR);
+    assertEquals(test.getCurrency(), USD);
+    assertEquals(test.getName(), "USD-LIBOR-3M");
+    assertEquals(test.getTenor(), TENOR_3M);
+    assertEquals(test.getFixingCalendar(), GBLO);
+    assertEquals(test.getEffectiveDateOffset(),
+        DaysAdjustment.ofBusinessDays(2, GBLO, BusinessDayAdjustment.of(FOLLOWING, GBLO.combineWith(USNY))));
+    assertEquals(test.getMaturityDateOffset(),
+        TenorAdjustment.ofLastBusinessDay(TENOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, GBLO.combineWith(USNY))));
+    assertEquals(test.getDayCount(), ACT_360);
+    assertEquals(test.toString(), "USD-LIBOR-3M");
+  }
+
+  public void test_usdLibor3m_dates() {
+    IborIndex test = IborIndex.of("USD-LIBOR-3M");
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 27)), date(2014, 10, 27));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 27)), date(2014, 10, 29));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 29)), date(2014, 10, 27));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 29)), date(2015, 1, 29));
+    // weekend
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 10)), date(2014, 10, 14));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 14)), date(2014, 10, 10));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 14)), date(2015, 1, 14));
+    // effective date is US holiday
+    assertEquals(test.calculatePublicationFromFixing(date(2015, 1, 16)), date(2015, 1, 16));
+    assertEquals(test.calculateEffectiveFromFixing(date(2015, 1, 16)), date(2015, 1, 20));
+    assertEquals(test.calculateFixingFromEffective(date(2015, 1, 20)), date(2015, 1, 16));
+    assertEquals(test.calculateMaturityFromEffective(date(2015, 1, 20)), date(2015, 4, 20));
+    // input date is Sunday, 13th is US holiday, but not UK holiday (can fix, but not be effective)
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 12)), date(2014, 10, 15));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 12)), date(2014, 10, 10));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 12)), date(2015, 1, 14));
+  }
+
+  public void test_euibor3m() {
+    IborIndex test = IborIndex.of("EURIBOR-3M");
+    assertEquals(test.getType(), RateIndexType.TENOR);
+    assertEquals(test.getCurrency(), EUR);
+    assertEquals(test.getName(), "EURIBOR-3M");
+    assertEquals(test.getTenor(), TENOR_3M);
+    assertEquals(test.getFixingCalendar(), EUTA);
+    assertEquals(test.getEffectiveDateOffset(), DaysAdjustment.ofBusinessDays(2, EUTA));
+    assertEquals(test.getMaturityDateOffset(),
+        TenorAdjustment.ofLastBusinessDay(TENOR_3M, BusinessDayAdjustment.of(MODIFIED_FOLLOWING, EUTA)));
+    assertEquals(test.getDayCount(), ACT_360);
+    assertEquals(test.toString(), "EURIBOR-3M");
+  }
+
+  public void test_euribor3m_dates() {
+    IborIndex test = IborIndex.of("EURIBOR-3M");
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 27)), date(2014, 10, 27));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 27)), date(2014, 10, 29));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 29)), date(2014, 10, 27));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 29)), date(2015, 1, 29));
+    // weekend
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 10)), date(2014, 10, 14));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 14)), date(2014, 10, 10));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 14)), date(2015, 1, 14));
+    // input date is Sunday
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 12)), date(2014, 10, 15));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 12)), date(2014, 10, 9));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 12)), date(2015, 1, 13));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_equals() {
+    IborIndex a = IborIndex.builder()
+        .name("OGIBOR")
+        .currency(Currency.GBP)
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+        .maturityDateOffset(TenorAdjustment.ofLastBusinessDay(TENOR_3M, BusinessDayAdjustment.NONE))
+        .dayCount(ACT_360)
+        .build();
+    IborIndex b = a.toBuilder().currency(Currency.USD).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().name("Rubbish").build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().fixingCalendar(USNY).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, USNY)).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().maturityDateOffset(TenorAdjustment.ofLastBusinessDay(TENOR_6M, BusinessDayAdjustment.NONE)).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().dayCount(ACT_365F).build();
+    assertEquals(a.equals(b), false);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    IborIndex index = IborIndex.builder()
+        .currency(Currency.GBP)
+        .name("OGIBOR")
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+        .maturityDateOffset(TenorAdjustment.ofLastBusinessDay(TENOR_3M, BusinessDayAdjustment.NONE))
+        .dayCount(ACT_360)
+        .build();
+    coverImmutableBean(index);
+    coverPrivateConstructor(StandardIborIndices.class);
+  }
+
+  public void test_jodaConvert() {
+    assertJodaConvert(RateIndex.class, RateIndices.GBP_LIBOR_12M);
+  }
+
+  public void test_serialization() {
+    IborIndex index = IborIndex.builder()
+        .currency(Currency.GBP)
+        .name("OGIBOR")
+        .fixingCalendar(GBLO)
+        .effectiveDateOffset(DaysAdjustment.ofBusinessDays(2, GBLO))
+        .maturityDateOffset(TenorAdjustment.ofLastBusinessDay(TENOR_3M, BusinessDayAdjustment.NONE))
+        .dayCount(ACT_360)
+        .build();
+    assertSerialization(index);
+  }
+
+}

--- a/basics/src/test/java/com/opengamma/basics/index/OvernightIndexTest.java
+++ b/basics/src/test/java/com/opengamma/basics/index/OvernightIndexTest.java
@@ -1,0 +1,158 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import static com.opengamma.basics.currency.Currency.GBP;
+import static com.opengamma.basics.currency.Currency.USD;
+import static com.opengamma.basics.date.DayCounts.ACT_360;
+import static com.opengamma.basics.date.DayCounts.ACT_365F;
+import static com.opengamma.basics.date.HolidayCalendars.GBLO;
+import static com.opengamma.basics.date.HolidayCalendars.NYFD;
+import static com.opengamma.basics.date.HolidayCalendars.USNY;
+import static com.opengamma.basics.date.Tenor.TENOR_1D;
+import static com.opengamma.collect.TestHelper.assertJodaConvert;
+import static com.opengamma.collect.TestHelper.assertSerialization;
+import static com.opengamma.collect.TestHelper.assertThrows;
+import static com.opengamma.collect.TestHelper.coverImmutableBean;
+import static com.opengamma.collect.TestHelper.coverPrivateConstructor;
+import static com.opengamma.collect.TestHelper.date;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.Test;
+
+import com.opengamma.basics.currency.Currency;
+
+/**
+ * Test Overnight Index.
+ */
+@Test
+public class OvernightIndexTest {
+
+  public void test_null() {
+    OvernightIndex test = OvernightIndex.of("GBP-SONIA");
+    assertThrows(() -> test.calculatePublicationFromFixing(null), IllegalArgumentException.class);
+    assertThrows(() -> test.calculateEffectiveFromFixing(null), IllegalArgumentException.class);
+    assertThrows(() -> test.calculateFixingFromEffective(null), IllegalArgumentException.class);
+    assertThrows(() -> test.calculateMaturityFromEffective(null), IllegalArgumentException.class);
+  }
+
+  public void test_gbpSonia() {
+    OvernightIndex test = OvernightIndex.of("GBP-SONIA");
+    assertEquals(test.getType(), RateIndexType.OVERNIGHT);
+    assertEquals(test.getCurrency(), GBP);
+    assertEquals(test.getName(), "GBP-SONIA");
+    assertEquals(test.getTenor(), TENOR_1D);
+    assertEquals(test.getCalendar(), GBLO);
+    assertEquals(test.getPublicationDateOffset(), 0);
+    assertEquals(test.getEffectiveDateOffset(), 0);
+    assertEquals(test.getDayCount(), ACT_365F);
+    assertEquals(test.toString(), "GBP-SONIA");
+  }
+
+  public void test_gbpSonia_dates() {
+    OvernightIndex test = OvernightIndex.of("GBP-SONIA");
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 13)), date(2014, 10, 13));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 13)), date(2014, 10, 13));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 13)), date(2014, 10, 13));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 13)), date(2014, 10, 14));
+    // weekend
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 10)), date(2014, 10, 13));
+    // input date is Sunday
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 12)), date(2014, 10, 13));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 12)), date(2014, 10, 14));
+  }
+
+  public void test_usdFedFund3m() {
+    OvernightIndex test = OvernightIndex.of("USD-FED-FUND");
+    assertEquals(test.getType(), RateIndexType.OVERNIGHT);
+    assertEquals(test.getCurrency(), USD);
+    assertEquals(test.getName(), "USD-FED-FUND");
+    assertEquals(test.getTenor(), TENOR_1D);
+    assertEquals(test.getCalendar(), NYFD);
+    assertEquals(test.getPublicationDateOffset(), 1);
+    assertEquals(test.getEffectiveDateOffset(), 0);
+    assertEquals(test.getDayCount(), ACT_360);
+    assertEquals(test.toString(), "USD-FED-FUND");
+  }
+
+  public void test_usdFedFund_dates() {
+    OvernightIndex test = OvernightIndex.of("USD-FED-FUND");
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 27)), date(2014, 10, 28));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 27)), date(2014, 10, 27));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 27)), date(2014, 10, 27));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 27)), date(2014, 10, 28));
+    // weekend and US holiday
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 10)), date(2014, 10, 14));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 10)), date(2014, 10, 10));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 10)), date(2014, 10, 14));
+    // input date is Sunday, 13th is US holiday
+    assertEquals(test.calculatePublicationFromFixing(date(2014, 10, 12)), date(2014, 10, 15));
+    assertEquals(test.calculateEffectiveFromFixing(date(2014, 10, 12)), date(2014, 10, 14));
+    assertEquals(test.calculateFixingFromEffective(date(2014, 10, 12)), date(2014, 10, 14));
+    assertEquals(test.calculateMaturityFromEffective(date(2014, 10, 12)), date(2014, 10, 15));
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_equals() {
+    OvernightIndex a = OvernightIndex.builder()
+        .currency(Currency.GBP)
+        .name("OGIBOR")
+        .calendar(GBLO)
+        .publicationDateOffset(0)
+        .effectiveDateOffset(0)
+        .dayCount(ACT_360)
+        .build();
+    OvernightIndex b = a.toBuilder().currency(Currency.USD).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().name("Rubbish").build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().calendar(USNY).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().publicationDateOffset(1).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().effectiveDateOffset(1).build();
+    assertEquals(a.equals(b), false);
+    b = a.toBuilder().dayCount(ACT_365F).build();
+    assertEquals(a.equals(b), false);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    OvernightIndex index = OvernightIndex.builder()
+        .currency(Currency.GBP)
+        .name("OGONIA")
+        .calendar(GBLO)
+        .publicationDateOffset(0)
+        .effectiveDateOffset(0)
+        .dayCount(ACT_360)
+        .build();
+    coverImmutableBean(index);
+    coverPrivateConstructor(StandardOvernightIndices.class);
+  }
+
+  public void test_jodaConvert() {
+    assertJodaConvert(RateIndex.class, RateIndices.GBP_SONIA);
+  }
+
+  public void test_serialization() {
+    OvernightIndex index = OvernightIndex.builder()
+        .currency(Currency.GBP)
+        .name("OGONIA")
+        .calendar(GBLO)
+        .publicationDateOffset(0)
+        .effectiveDateOffset(0)
+        .dayCount(ACT_360)
+        .build();
+    assertSerialization(index);
+  }
+
+}

--- a/basics/src/test/java/com/opengamma/basics/index/RateIndexTest.java
+++ b/basics/src/test/java/com/opengamma/basics/index/RateIndexTest.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ * 
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import static com.opengamma.collect.TestHelper.assertThrows;
+import static com.opengamma.collect.TestHelper.coverPrivateConstructor;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+/**
+ * Test {@link RateIndex}.
+ */
+@Test
+public class RateIndexTest {
+
+  //-------------------------------------------------------------------------
+  @DataProvider(name = "name")
+  static Object[][] data_name() {
+      return new Object[][] {
+          {RateIndices.GBP_LIBOR_6M, "GBP-LIBOR-6M"},
+          {RateIndices.CHF_LIBOR_6M, "CHF-LIBOR-6M"},
+          {RateIndices.EUR_LIBOR_6M, "EUR-LIBOR-6M"},
+          {RateIndices.JPY_LIBOR_6M, "JPY-LIBOR-6M"},
+          {RateIndices.USD_LIBOR_6M, "USD-LIBOR-6M"},
+          {RateIndices.EURIBOR_1M, "EURIBOR-1M"},
+          {RateIndices.JPY_TIBOR_JAPAN_2M, "JPY-TIBOR-JAPAN-2M"},
+          {RateIndices.JPY_TIBOR_EUROYEN_6M, "JPY-TIBOR-EUROYEN-6M"},
+      };
+  }
+
+  @Test(dataProvider = "name")
+  public void test_name(RateIndex convention, String name) {
+    assertEquals(convention.getName(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_toString(RateIndex convention, String name) {
+    assertEquals(convention.toString(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_of_lookup(RateIndex convention, String name) {
+    assertEquals(RateIndex.of(name), convention);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_extendedEnum(RateIndex convention, String name) {
+    ImmutableMap<String, RateIndex> map = RateIndex.extendedEnum().lookupAll();
+    assertEquals(map.get(name), convention);
+  }
+
+  public void test_of_lookup_notFound() {
+    assertThrows(() -> RateIndex.of("Rubbish"), IllegalArgumentException.class);
+  }
+
+  public void test_of_lookup_null() {
+    assertThrows(() -> RateIndex.of(null), IllegalArgumentException.class);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverPrivateConstructor(RateIndices.class);
+  }
+
+}

--- a/basics/src/test/java/com/opengamma/basics/index/RateIndexTypeTest.java
+++ b/basics/src/test/java/com/opengamma/basics/index/RateIndexTypeTest.java
@@ -1,0 +1,63 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
+package com.opengamma.basics.index;
+
+import static com.opengamma.collect.TestHelper.assertJodaConvert;
+import static com.opengamma.collect.TestHelper.assertSerialization;
+import static com.opengamma.collect.TestHelper.assertThrows;
+import static com.opengamma.collect.TestHelper.coverEnum;
+import static org.testng.Assert.assertEquals;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for the rate index type class.
+ */
+@Test
+public class RateIndexTypeTest {
+
+  @DataProvider(name = "name")
+  static Object[][] data_name() {
+      return new Object[][] {
+          {RateIndexType.OVERNIGHT, "Overnight"},
+          {RateIndexType.TENOR, "Tenor"},
+      };
+  }
+
+  @Test(dataProvider = "name")
+  public void test_toString(RateIndexType convention, String name) {
+    assertEquals(convention.toString(), name);
+  }
+
+  @Test(dataProvider = "name")
+  public void test_of_lookup(RateIndexType convention, String name) {
+    assertEquals(RateIndexType.of(name), convention);
+  }
+
+  public void test_of_lookup_notFound() {
+    assertThrows(() -> RateIndexType.of("Rubbish"), IllegalArgumentException.class);
+  }
+
+  public void test_of_lookup_null() {
+    assertThrows(() -> RateIndexType.of(null), IllegalArgumentException.class);
+  }
+
+  //-------------------------------------------------------------------------
+  public void coverage() {
+    coverEnum(RateIndexType.class);
+  }
+
+  public void test_serialization() {
+    assertSerialization(RateIndexType.OVERNIGHT);
+  }
+
+  public void test_jodaConvert() {
+    assertJodaConvert(RateIndexType.class, RateIndexType.TENOR);
+  }
+
+}
+


### PR DESCRIPTION
Create standard classes to support IBOR and Overnight indices
Add conventions/implementations for common cases
Handle GBP, EUR, CHF, JPY, USD

Design is fairly straightforward, a single interface and two immutable bean implementations. A standard set of constants supply the common conventions. Expansion to other conventions is likely to be via a separate database lookup.
