### PR TITLE
PLT-488 - TestHelper assertThrows should output actual exception

### DIFF
--- a/collect/src/test/java/com/opengamma/collect/TestHelper.java
+++ b/collect/src/test/java/com/opengamma/collect/TestHelper.java
@@ -222,7 +222,7 @@ public class TestHelper {
           fail("Expected exception message to match: [" + regex + "] but received: " + message);
         }
       }
-      fail("Expected " + expected.getSimpleName() + " but received " + ex.getClass().getSimpleName());
+      fail("Expected " + expected.getSimpleName() + " but received " + ex.getClass().getSimpleName(), ex);
     }
   }
 


### PR DESCRIPTION
When an exception is thrown but is not of expected type, the actual exception thrown is included in the failure message. Compare before:

```
java.lang.AssertionError: Expected SQLIntegrityConstraintViolationException but received BadSqlGrammarException
    at org.testng.Assert.fail(Assert.java:94)
    at com.opengamma.collect.TestHelper.assertThrowsImpl(TestHelper.java:225)
    at com.opengamma.collect.TestHelper.assertThrows(TestHelper.java:181)
    at com.opengamma.platform.masterdb.SchemaTest.documentVersionInsertion(SchemaTest.java:112)
```

with after:

```
java.lang.AssertionError: Expected SQLIntegrityConstraintViolationException but received BadSqlGrammarException
    at org.testng.Assert.fail(Assert.java:83)
    at com.opengamma.collect.TestHelper.assertThrowsImpl(TestHelper.java:225)
    at com.opengamma.collect.TestHelper.assertThrows(TestHelper.java:181)
    at com.opengamma.platform.masterdb.SchemaTest.documentVersionInsertion(SchemaTest.java:112)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:84)
    at org.testng.internal.Invoker.invokeMethod(Invoker.java:714)
    at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:901)
    at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1231)
    at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:127)
    at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:111)
    at org.testng.TestRunner.privateRun(TestRunner.java:767)
    at org.testng.TestRunner.run(TestRunner.java:617)
    at org.testng.SuiteRunner.runTest(SuiteRunner.java:348)
    at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:343)
    at org.testng.SuiteRunner.privateRun(SuiteRunner.java:305)
    at org.testng.SuiteRunner.run(SuiteRunner.java:254)
    at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
    at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
    at org.testng.TestNG.runSuitesSequentially(TestNG.java:1224)
    at org.testng.TestNG.runSuitesLocally(TestNG.java:1149)
    at org.testng.TestNG.run(TestNG.java:1057)
    at org.testng.remote.RemoteTestNG.run(RemoteTestNG.java:111)
    at org.testng.remote.RemoteTestNG.initAndRun(RemoteTestNG.java:204)
    at org.testng.remote.RemoteTestNG.main(RemoteTestNG.java:175)
    at org.testng.RemoteTestNGStarter.main(RemoteTestNGStarter.java:125)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:483)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:134)
Caused by: org.springframework.jdbc.BadSqlGrammarException: PreparedStatementCallback; bad SQL grammar [insert into document_version (id, oid, version_from, corrected_from, bean_data) values (?, ?, ?, ?, ?)]; nested exception is java.sql.SQLSyntaxErrorException: incompatible data type in conversion
    at org.springframework.jdbc.support.SQLExceptionSubclassTranslator.doTranslate(SQLExceptionSubclassTranslator.java:95)
    at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:73)
    at org.springframework.jdbc.support.AbstractFallbackSQLExceptionTranslator.translate(AbstractFallbackSQLExceptionTranslator.java:81)
    at org.springframework.jdbc.core.JdbcTemplate.execute(JdbcTemplate.java:660)
    at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:909)
    at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:970)
    at org.springframework.jdbc.core.JdbcTemplate.update(JdbcTemplate.java:980)
    at com.opengamma.platform.masterdb.SchemaTest.lambda$documentVersionInsertion$1(SchemaTest.java:113)
    at com.opengamma.platform.masterdb.SchemaTest$$Lambda$1/1175371136.run(Unknown Source)
    at com.opengamma.collect.TestHelper.assertThrowsImpl(TestHelper.java:212)
    ... 32 more
```
