### PR TITLE
PLT-486 - Bug fix for new ResultAssert

### DIFF
--- a/collect/src/test/java/com/opengamma/collect/ResultAssert.java
+++ b/collect/src/test/java/com/opengamma/collect/ResultAssert.java
@@ -121,7 +121,7 @@ public class ResultAssert extends AbstractAssert<ResultAssert, Result<?>> {
    *   throw an {@code AssertionError}
    */
   public ResultAssert isFailure(FailureReason expected) {
-    isNotNull();
+    isFailure();
 
     FailureReason actualReason = actual.getFailure().getReason();
     if (actualReason != expected) {


### PR DESCRIPTION
Message wasn't correct when expected failure was actually success as we hadn't actually validated that the result was a failure.
