### PR TITLE
PLT-513 Add Frequency.exactDivide()

### DIFF
--- a/basics/src/main/java/com/opengamma/basics/schedule/Frequency.java
+++ b/basics/src/main/java/com/opengamma/basics/schedule/Frequency.java
@@ -373,7 +373,7 @@ public final class Frequency
    * Not all periodic frequency instances can be converted to an integer events per year.
    * All constants declared on this class will return a result.
    * <p>
-   * Month-based periodic frequencies are converted by dividing 12 by the number of months.
+   * Month-based and year-based periodic frequencies are converted by dividing 12 by the number of months.
    * Only the following periodic frequencies return a value - P1M, P2M, P3M, P4M, P6M, P1Y.
    * <p>
    * Day-based and week-based periodic frequencies are converted by dividing 364 by the number of days.
@@ -407,11 +407,11 @@ public final class Frequency
    * This calculates the integer division of this frequency by the specified frequency.
    * If the result is not an integer, an exception is thrown.
    * <p>
-   * Month-based periodic frequencies are calculated by dividing the total number of months.
-   * For example, P6M divided by P3M results in 2.
+   * Month-based and year-based periodic frequencies are calculated by dividing the total number of months.
+   * For example, P6M divided by P3M results in 2, and P2Y divided by P6M returns 4.
    * <p>
    * Day-based and week-based periodic frequencies are calculated by dividing the total number of days.
-   * For example, P26W divided by P13W results in 2.
+   * For example, P26W divided by P13W results in 2, and P2W divided by P1D returns 14.
    * <p>
    * The 'Term' frequency throws an exception.
    *

--- a/basics/src/test/java/com/opengamma/basics/schedule/FrequencyTest.java
+++ b/basics/src/test/java/com/opengamma/basics/schedule/FrequencyTest.java
@@ -280,6 +280,9 @@ public class FrequencyTest {
         {Frequency.P6M, Frequency.P2M, 3},
         {Frequency.P12M, Frequency.P1M, 12},
         {Frequency.P12M, Frequency.P2M, 6},
+        {Frequency.ofYears(1), Frequency.P6M, 2},
+        {Frequency.ofYears(1), Frequency.P3M, 4},
+        {Frequency.ofYears(2), Frequency.P6M, 4},
     };
   }
 
@@ -291,7 +294,7 @@ public class FrequencyTest {
   @Test(dataProvider = "exactDivide")
   public void test_exactDivide_reverse(Frequency test, Frequency other, int expected) {
     if (!test.equals(other)) {
-      assertThrowsIllegalArg(() -> Frequency.P1W.exactDivide(Frequency.P1M));
+      assertThrowsIllegalArg(() -> other.exactDivide(test));
     }
   }
 
@@ -302,6 +305,7 @@ public class FrequencyTest {
     assertThrowsIllegalArg(() -> Frequency.P1W.exactDivide(Frequency.P1M));
     assertThrowsIllegalArg(() -> Frequency.TERM.exactDivide(Frequency.P1W));
     assertThrowsIllegalArg(() -> Frequency.P12M.exactDivide(Frequency.TERM));
+    assertThrowsIllegalArg(() -> Frequency.ofYears(1).exactDivide(Frequency.P1W));
   }
 
   //-------------------------------------------------------------------------


### PR DESCRIPTION
Provides a mechanism to divide one frequency by another

When working with schedules, it is useful to be able to divide one frequency by another. This operation is only expected to succeed if the frequencies are compatible, such as dividing a payment frequency of P6M by an accrual frequency of P3M.
