### PR TITLE
PLT-590 MultiCurrencyAmount.collector

### DIFF
--- a/modules/basics/src/main/java/com/opengamma/basics/currency/MultiCurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/basics/currency/MultiCurrencyAmount.java
@@ -152,7 +152,7 @@ public final class MultiCurrencyAmount
             (map, ca) -> map.merge(ArgChecker.notNull(ca, "amount").getCurrency(), ca, CurrencyAmount::plus),
             // combine two maps
             (map1, map2) -> {
-              map1.putAll(map2);
+              map2.values().forEach((ca2) -> map1.merge(ca2.getCurrency(), ca2, CurrencyAmount::plus));
               return map1;
             },
             // convert to MultiCurrencyAmount
@@ -170,6 +170,7 @@ public final class MultiCurrencyAmount
    */
   private static Collector<CurrencyAmount, ?, MultiCurrencyAmount> collectorInternal() {
     // this method must not be exposed publicly as misuse creates an instance with invalid state
+    // it exists because when used internally it offers better performance than collector()
     return Collectors.collectingAndThen(
         Guavate.toImmutableSortedSet(),
         MultiCurrencyAmount::new);

--- a/modules/basics/src/main/java/com/opengamma/basics/currency/MultiCurrencyAmount.java
+++ b/modules/basics/src/main/java/com/opengamma/basics/currency/MultiCurrencyAmount.java
@@ -156,7 +156,7 @@ public final class MultiCurrencyAmount
               return map1;
             },
             // convert to MultiCurrencyAmount
-            (map) -> new MultiCurrencyAmount(ImmutableSortedSet.copyOf(map.values())),
+            map -> new MultiCurrencyAmount(ImmutableSortedSet.copyOf(map.values())),
             UNORDERED);
   }
 

--- a/modules/basics/src/test/java/com/opengamma/basics/currency/MultiCurrencyAmountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/basics/currency/MultiCurrencyAmountTest.java
@@ -13,12 +13,14 @@ import static org.testng.Assert.assertEquals;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 import org.joda.beans.BeanBuilder;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSortedMap;
@@ -117,6 +119,21 @@ public class MultiCurrencyAmountTest {
   public void test_total_Iterable_containsNull() {
     Iterable<CurrencyAmount> iterable = Arrays.asList(CA1, null, CA2);
     assertThrows(() -> MultiCurrencyAmount.total(iterable), IllegalArgumentException.class);
+  }
+
+  //-------------------------------------------------------------------------
+  public void test_collector() {
+    List<CurrencyAmount> amount = ImmutableList.of(
+        CurrencyAmount.of(CCY1, 100), CurrencyAmount.of(CCY1, 150), CurrencyAmount.of(CCY2, 100));
+    MultiCurrencyAmount test = amount.stream().collect(MultiCurrencyAmount.collector());
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(CurrencyAmount.of(CCY1, 250), CurrencyAmount.of(CCY2, 100));
+    assertEquals(test, expected);
+  }
+
+  public void test_collector_null() {
+    List<CurrencyAmount> amount = Arrays.asList(
+        CurrencyAmount.of(CCY1, 100), null, CurrencyAmount.of(CCY2, 100));
+    assertThrowsIllegalArg(() -> amount.stream().collect(MultiCurrencyAmount.collector()));
   }
 
   //-------------------------------------------------------------------------

--- a/modules/basics/src/test/java/com/opengamma/basics/currency/MultiCurrencyAmountTest.java
+++ b/modules/basics/src/test/java/com/opengamma/basics/currency/MultiCurrencyAmountTest.java
@@ -130,6 +130,14 @@ public class MultiCurrencyAmountTest {
     assertEquals(test, expected);
   }
 
+  public void test_collector_parallel() {
+    List<CurrencyAmount> amount = ImmutableList.of(
+        CurrencyAmount.of(CCY1, 100), CurrencyAmount.of(CCY1, 150), CurrencyAmount.of(CCY2, 100));
+    MultiCurrencyAmount test = amount.parallelStream().collect(MultiCurrencyAmount.collector());
+    MultiCurrencyAmount expected = MultiCurrencyAmount.of(CurrencyAmount.of(CCY1, 250), CurrencyAmount.of(CCY2, 100));
+    assertEquals(test, expected);
+  }
+
   public void test_collector_null() {
     List<CurrencyAmount> amount = Arrays.asList(
         CurrencyAmount.of(CCY1, 100), null, CurrencyAmount.of(CCY2, 100));


### PR DESCRIPTION
Existing implementation fails with same currency twice in input.
Write dedicated totalling collector and use it where appropriate.
Use new collector instead of current total() enabling optimised plus() methods.