### PR TITLE
PLT-678 - Assertion helper for Java 8 Optional

### DIFF
--- a/modules/collect/src/test/java/com/opengamma/collect/CollectProjectAssertions.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/CollectProjectAssertions.java
@@ -5,6 +5,8 @@
  */
 package com.opengamma.collect;
 
+import java.util.Optional;
+
 import org.assertj.core.api.Assertions;
 
 import com.opengamma.collect.result.Result;
@@ -28,5 +30,16 @@ public class CollectProjectAssertions extends Assertions {
    */
   public static ResultAssert assertThat(Result<?> result) {
     return ResultAssert.assertThat(result);
+  }
+
+  /**
+   * Create an {@code Assert} instance that enables
+   * assertions on {@code Optional} objects.
+   *
+   * @param optional  the optional to create an {@code Assert} for
+   * @return an {@code Assert} instance
+   */
+  public static <T> OptionalAssert<T> assertThat(Optional<T> optional) {
+    return OptionalAssert.assertThat(optional);
   }
 }

--- a/modules/collect/src/test/java/com/opengamma/collect/OptionalAssert.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/OptionalAssert.java
@@ -1,4 +1,8 @@
-
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
 package com.opengamma.collect;
 
 import java.util.Optional;

--- a/modules/collect/src/test/java/com/opengamma/collect/OptionalAssert.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/OptionalAssert.java
@@ -1,0 +1,93 @@
+
+package com.opengamma.collect;
+
+import java.util.Optional;
+
+import org.assertj.core.api.AbstractAssert;
+
+/**
+ * An assert helper that provides useful AssertJ assertion
+ * methods for {@link Optional} instances.
+ * <p>
+ * These allow {@code Optional} instances to be inspected in tests in the
+ * same fluent style as other basic classes.
+ * <p>
+ * So the following:
+ * <pre>
+ *   Optional{@literal <SomeType>} optional = someMethodCall();
+ *   assertTrue(optional.isPresent());
+ *   assertEquals(optional.get(), SomeType.EXPECTED);
+ * </pre>
+ * can be replaced with:
+ * <pre>
+ *   Optional{@literal <SomeType>} optional = someMethodCall();
+ *   assertThat(optional)
+ *     .isPresent()
+ *     .hasValue(SomeType.EXPECTED);
+ * </pre>
+ * In order to be able to use a statically imported assertThat()
+ * method for both {@code Optional} and other types, statically
+ * import {@link CollectProjectAssertions#assertThat}
+ * rather than this class.
+ *
+ * @param <T> the type of the value in the {@code Optional}.
+ */
+public class OptionalAssert<T> extends AbstractAssert<OptionalAssert<T>, Optional<T>> {
+
+  private OptionalAssert(Optional<T> actual) {
+    super(actual, OptionalAssert.class);
+  }
+
+  /**
+   * Create an {@code Assert} instance for the supplied {@code Optional}.
+   *
+   * @param optional  the optional to create an {@code Assert} for
+   * @param <T>  the type of the optional value
+   * @return an {@code Assert} instance
+   */
+  public static <T> OptionalAssert<T> assertThat(Optional<T> optional) {
+    return new OptionalAssert<>(optional);
+  }
+
+  /**
+   * Assert that the {@code Optional} contains a value.
+   *
+   * @return this if the {@code Optional} contains a value, else throw an {@code AssertionError}
+   */
+  public OptionalAssert<T> isPresent() {
+    isNotNull();
+
+    if (!actual.isPresent()) {
+      failWithMessage("Expected a value but Optional was empty");
+    }
+    return this;
+  }
+
+  /**
+   * Assert that the {@code Optional} is empty.
+   *
+   * @return this if the {@code Optional} is empty, else throw an {@code AssertionError}
+   */
+  public OptionalAssert<T> isEmpty() {
+    isNotNull();
+
+    if (actual.isPresent()) {
+      failWithMessage("Expected empty Optional but found value <%s>", actual.get());
+    }
+    return this;
+  }
+
+  /**
+   * Assert that the {@code Optional} contains a particular value.
+   *
+   * @return this if the {@code Optional} contains the specified value, else throw an {@code AssertionError}
+   */
+  public OptionalAssert<T> hasValue(T value) {
+    isPresent();
+
+    if (!actual.get().equals(value)) {
+      failWithMessage("Expected Optional with value: <%s> but was <%s>", value, actual.get());
+    }
+    return this;
+  }
+}

--- a/modules/collect/src/test/java/com/opengamma/collect/OptionalAssertTest.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/OptionalAssertTest.java
@@ -1,0 +1,46 @@
+package com.opengamma.collect;
+
+import static com.opengamma.collect.CollectProjectAssertions.assertThat;
+
+import java.util.Optional;
+
+import org.testng.annotations.Test;
+
+@Test
+public class OptionalAssertTest {
+
+  private static final Optional<String> PRESENT = Optional.of("foo");
+  private static final Optional<String> EMPTY = Optional.empty();
+
+  public void isPresent() {
+    assertThat(PRESENT).isPresent();
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void isPresentFail() {
+    assertThat(EMPTY).isPresent();
+  }
+
+  public void isEmpty() {
+    assertThat(EMPTY).isEmpty();
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void isEmptyFail() {
+    assertThat(PRESENT).isEmpty();
+  }
+
+  public void hasValue() {
+    assertThat(PRESENT).hasValue("foo");
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void hasValueFail() {
+    assertThat(EMPTY).hasValue("foo");
+  }
+
+  @Test(expectedExceptions = AssertionError.class)
+  public void hasValueFail2() {
+    assertThat(PRESENT).hasValue("bar");
+  }
+}

--- a/modules/collect/src/test/java/com/opengamma/collect/OptionalAssertTest.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/OptionalAssertTest.java
@@ -1,3 +1,8 @@
+/**
+ * Copyright (C) 2014 - present by OpenGamma Inc. and the OpenGamma group of companies
+ *
+ * Please see distribution for license.
+ */
 package com.opengamma.collect;
 
 import static com.opengamma.collect.CollectProjectAssertions.assertThat;


### PR DESCRIPTION
This PR creates a helper class enabling nicer AssertJ assertions for Java 8 ``Optional``. It's based on the equivalent helper for ``Result``.