### PR TITLE
STR-50 - Add in partition methods to LocalDateDoubleTimeSeries

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/collect/timeseries/LocalDateDoubleTimeSeries.java
+++ b/modules/collect/src/main/java/com/opengamma/collect/timeseries/LocalDateDoubleTimeSeries.java
@@ -305,7 +305,7 @@ public interface LocalDateDoubleTimeSeries extends ImmutableBean {
 
   /**
    * Partition the timeseries into a pair of distinct series using a predicate.
-   *
+   * <p>
    * Points in the timeseries which match the predicate will be put into the
    * first series, whilst those points which do not match will be put into the
    * second.
@@ -329,15 +329,15 @@ public interface LocalDateDoubleTimeSeries extends ImmutableBean {
 
   /**
    * Partition the timeseries into a pair of distinct series using a predicate.
-   *
+   * <p>
    * Points in the timeseries whose values match the predicate will be put into the
    * first series, whilst those points whose values do not match will be put into the
    * second.
    *
    * @param predicate  predicate used to test the points in the timeseries
    * @return a {@code Pair} containing two timeseries. The first is a series
-   * made of all the points in this series which match the predicate. The
-   * second is a series made of the points which do not match.
+   *   made of all the points in this series which match the predicate. The
+   *   second is a series made of the points which do not match.
    */
   public default Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partitionByValue(
       DoublePredicate predicate) {

--- a/modules/collect/src/main/java/com/opengamma/collect/timeseries/LocalDateDoubleTimeSeries.java
+++ b/modules/collect/src/main/java/com/opengamma/collect/timeseries/LocalDateDoubleTimeSeries.java
@@ -5,10 +5,14 @@
  */
 package com.opengamma.collect.timeseries;
 
+import static java.util.stream.Collectors.partitioningBy;
+
 import java.time.LocalDate;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.OptionalDouble;
 import java.util.function.DoubleBinaryOperator;
+import java.util.function.DoublePredicate;
 import java.util.function.DoubleUnaryOperator;
 import java.util.function.ObjDoubleConsumer;
 import java.util.stream.Collector;
@@ -19,6 +23,8 @@ import org.joda.beans.ImmutableBean;
 
 import com.opengamma.collect.ArgChecker;
 import com.opengamma.collect.function.ObjDoublePredicate;
+import com.opengamma.collect.tuple.Pair;
+
 
 /**
  * Interface for all local date time-series types containing
@@ -295,6 +301,47 @@ public interface LocalDateDoubleTimeSeries extends ImmutableBean {
                 pt.getDate(),
                 mapper.applyAsDouble(pt.getValue(), other.get(pt.getDate()).getAsDouble()))))
         .build();
+  }
+
+  /**
+   * Partition the timeseries into a pair of distinct series using a predicate.
+   *
+   * Points in the timeseries which match the predicate will be put into the
+   * first series, whilst those points which do not match will be put into the
+   * second.
+   *
+   * @param predicate  predicate used to test the points in the timeseries
+   * @return a {@code Pair} containing two timeseries. The first is a series
+   * made of all the points in this series which match the predicate. The
+   * second is a series made of the points which do not match.
+   */
+  public default Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partition(
+      ObjDoublePredicate<LocalDate> predicate) {
+
+    Map<Boolean, LocalDateDoubleTimeSeries> partitioned = stream()
+        .collect(
+            partitioningBy(
+                pt -> predicate.test(pt.getDate(), pt.getValue()),
+                LocalDateDoubleTimeSeries.collector()));
+
+    return Pair.of(partitioned.get(true), partitioned.get(false));
+  }
+
+  /**
+   * Partition the timeseries into a pair of distinct series using a predicate.
+   *
+   * Points in the timeseries whose values match the predicate will be put into the
+   * first series, whilst those points whose values do not match will be put into the
+   * second.
+   *
+   * @param predicate  predicate used to test the points in the timeseries
+   * @return a {@code Pair} containing two timeseries. The first is a series
+   * made of all the points in this series which match the predicate. The
+   * second is a series made of the points which do not match.
+   */
+  public default Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partitionByValue(
+      DoublePredicate predicate) {
+    return partition((obj, value) -> predicate.test(value));
   }
 
   /**

--- a/modules/collect/src/test/java/com/opengamma/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -744,15 +744,15 @@ public class DenseLocalDateDoubleTimeSeriesTest {
 
     LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(map).build();
     assertThat(ts.get(dt(2014, 12, 26))).hasValue(14d);
-    assertThat(ts.get(dt(2014, 12, 27))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2014, 12, 28))).isEqualTo(OptionalDouble.empty());
+    assertThat(ts.get(dt(2014, 12, 27))).isEmpty();
+    assertThat(ts.get(dt(2014, 12, 28))).isEmpty();
     assertThat(ts.get(dt(2014, 12, 29))).hasValue(13d);
     assertThat(ts.get(dt(2014, 12, 30))).hasValue(12d);
     assertThat(ts.get(dt(2014, 12, 31))).hasValue(11d);
-    assertThat(ts.get(dt(2015, 1, 1))).isEqualTo(OptionalDouble.empty());
+    assertThat(ts.get(dt(2015, 1, 1))).isEmpty();
     assertThat(ts.get(dt(2015, 1, 2))).hasValue(11d);
-    assertThat(ts.get(dt(2015, 1, 3))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2015, 1, 4))).isEqualTo(OptionalDouble.empty());
+    assertThat(ts.get(dt(2015, 1, 3))).isEmpty();
+    assertThat(ts.get(dt(2015, 1, 4))).isEmpty();
     assertThat(ts.get(dt(2015, 1, 5))).hasValue(12d);
     assertThat(ts.get(dt(2015, 1, 6))).hasValue(13d);
     assertThat(ts.get(dt(2015, 1, 7))).hasValue(14d);
@@ -799,10 +799,10 @@ public class DenseLocalDateDoubleTimeSeriesTest {
     assertThat(ts.get(dt(2014, 12, 29))).hasValue(13d);
     assertThat(ts.get(dt(2014, 12, 30))).hasValue(12d);
     assertThat(ts.get(dt(2014, 12, 31))).hasValue(11d);
-    assertThat(ts.get(dt(2015, 1, 1))).isEqualTo(OptionalDouble.empty());
+    assertThat(ts.get(dt(2015, 1, 1))).isEmpty();
     assertThat(ts.get(dt(2015, 1, 2))).hasValue(11d);
-    assertThat(ts.get(dt(2015, 1, 3))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2015, 1, 4))).isEqualTo(OptionalDouble.empty());
+    assertThat(ts.get(dt(2015, 1, 3))).isEmpty();
+    assertThat(ts.get(dt(2015, 1, 4))).isEmpty();
     assertThat(ts.get(dt(2015, 1, 5))).hasValue(12d);
     assertThat(ts.get(dt(2015, 1, 6))).hasValue(13d);
     assertThat(ts.get(dt(2015, 1, 7))).hasValue(14d);

--- a/modules/collect/src/test/java/com/opengamma/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
+++ b/modules/collect/src/test/java/com/opengamma/collect/timeseries/DenseLocalDateDoubleTimeSeriesTest.java
@@ -5,12 +5,12 @@
  */
 package com.opengamma.collect.timeseries;
 
+import static com.opengamma.collect.CollectProjectAssertions.assertThat;
 import static com.opengamma.collect.TestHelper.assertThrows;
 import static com.opengamma.collect.TestHelper.assertThrowsIllegalArg;
 import static com.opengamma.collect.timeseries.DenseLocalDateDoubleTimeSeries.DenseTimeSeriesCalculation.INCLUDE_WEEKENDS;
 import static com.opengamma.collect.timeseries.DenseLocalDateDoubleTimeSeries.DenseTimeSeriesCalculation.SKIP_WEEKENDS;
 import static com.opengamma.collect.timeseries.LocalDateDoubleTimeSeries.empty;
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 
@@ -34,6 +34,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.primitives.Doubles;
 import com.opengamma.collect.Guavate;
 import com.opengamma.collect.TestHelper;
+import com.opengamma.collect.tuple.Pair;
 
 @Test
 public class DenseLocalDateDoubleTimeSeriesTest {
@@ -742,19 +743,19 @@ public class DenseLocalDateDoubleTimeSeriesTest {
         .build();
 
     LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(map).build();
-    assertThat(ts.get(dt(2014, 12, 26))).isEqualTo(OptionalDouble.of(14d));
+    assertThat(ts.get(dt(2014, 12, 26))).hasValue(14d);
     assertThat(ts.get(dt(2014, 12, 27))).isEqualTo(OptionalDouble.empty());
     assertThat(ts.get(dt(2014, 12, 28))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2014, 12, 29))).isEqualTo(OptionalDouble.of(13d));
-    assertThat(ts.get(dt(2014, 12, 30))).isEqualTo(OptionalDouble.of(12d));
-    assertThat(ts.get(dt(2014, 12, 31))).isEqualTo(OptionalDouble.of(11d));
+    assertThat(ts.get(dt(2014, 12, 29))).hasValue(13d);
+    assertThat(ts.get(dt(2014, 12, 30))).hasValue(12d);
+    assertThat(ts.get(dt(2014, 12, 31))).hasValue(11d);
     assertThat(ts.get(dt(2015, 1, 1))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2015, 1, 2))).isEqualTo(OptionalDouble.of(11d));
+    assertThat(ts.get(dt(2015, 1, 2))).hasValue(11d);
     assertThat(ts.get(dt(2015, 1, 3))).isEqualTo(OptionalDouble.empty());
     assertThat(ts.get(dt(2015, 1, 4))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2015, 1, 5))).isEqualTo(OptionalDouble.of(12d));
-    assertThat(ts.get(dt(2015, 1, 6))).isEqualTo(OptionalDouble.of(13d));
-    assertThat(ts.get(dt(2015, 1, 7))).isEqualTo(OptionalDouble.of(14d));
+    assertThat(ts.get(dt(2015, 1, 5))).hasValue(12d);
+    assertThat(ts.get(dt(2015, 1, 6))).hasValue(13d);
+    assertThat(ts.get(dt(2015, 1, 7))).hasValue(14d);
   }
 
   //-------------------------------------------------------------------------
@@ -794,17 +795,17 @@ public class DenseLocalDateDoubleTimeSeriesTest {
         .build();
 
     LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(map).build();
-    assertThat(ts.get(dt(2014, 12, 26))).isEqualTo(OptionalDouble.of(14d));
-    assertThat(ts.get(dt(2014, 12, 29))).isEqualTo(OptionalDouble.of(13d));
-    assertThat(ts.get(dt(2014, 12, 30))).isEqualTo(OptionalDouble.of(12d));
-    assertThat(ts.get(dt(2014, 12, 31))).isEqualTo(OptionalDouble.of(11d));
+    assertThat(ts.get(dt(2014, 12, 26))).hasValue(14d);
+    assertThat(ts.get(dt(2014, 12, 29))).hasValue(13d);
+    assertThat(ts.get(dt(2014, 12, 30))).hasValue(12d);
+    assertThat(ts.get(dt(2014, 12, 31))).hasValue(11d);
     assertThat(ts.get(dt(2015, 1, 1))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2015, 1, 2))).isEqualTo(OptionalDouble.of(11d));
+    assertThat(ts.get(dt(2015, 1, 2))).hasValue(11d);
     assertThat(ts.get(dt(2015, 1, 3))).isEqualTo(OptionalDouble.empty());
     assertThat(ts.get(dt(2015, 1, 4))).isEqualTo(OptionalDouble.empty());
-    assertThat(ts.get(dt(2015, 1, 5))).isEqualTo(OptionalDouble.of(12d));
-    assertThat(ts.get(dt(2015, 1, 6))).isEqualTo(OptionalDouble.of(13d));
-    assertThat(ts.get(dt(2015, 1, 7))).isEqualTo(OptionalDouble.of(14d));
+    assertThat(ts.get(dt(2015, 1, 5))).hasValue(12d);
+    assertThat(ts.get(dt(2015, 1, 6))).hasValue(13d);
+    assertThat(ts.get(dt(2015, 1, 7))).hasValue(14d);
   }
 
   public void underOneWeekNoWeekend() {
@@ -818,8 +819,8 @@ public class DenseLocalDateDoubleTimeSeriesTest {
         .build();
 
     LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(map).build();
-    assertThat(ts.get(dt(2015, 1, 5))).isEqualTo(OptionalDouble.of(12d));
-    assertThat(ts.get(dt(2015, 1, 9))).isEqualTo(OptionalDouble.of(16d));
+    assertThat(ts.get(dt(2015, 1, 5))).hasValue(12d);
+    assertThat(ts.get(dt(2015, 1, 9))).hasValue(16d);
   }
 
   public void underOneWeekWithWeekend() {
@@ -835,13 +836,13 @@ public class DenseLocalDateDoubleTimeSeriesTest {
         .build();
 
     LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(map).build();
-    assertThat(ts.get(dt(2015, 1, 1))).isEqualTo(OptionalDouble.of(10d));
-    assertThat(ts.get(dt(2015, 1, 2))).isEqualTo(OptionalDouble.of(11d));
-    assertThat(ts.get(dt(2015, 1, 5))).isEqualTo(OptionalDouble.of(12d));
-    assertThat(ts.get(dt(2015, 1, 6))).isEqualTo(OptionalDouble.of(13d));
-    assertThat(ts.get(dt(2015, 1, 7))).isEqualTo(OptionalDouble.of(14d));
-    assertThat(ts.get(dt(2015, 1, 8))).isEqualTo(OptionalDouble.of(15d));
-    assertThat(ts.get(dt(2015, 1, 9))).isEqualTo(OptionalDouble.of(16d));
+    assertThat(ts.get(dt(2015, 1, 1))).hasValue(10d);
+    assertThat(ts.get(dt(2015, 1, 2))).hasValue(11d);
+    assertThat(ts.get(dt(2015, 1, 5))).hasValue(12d);
+    assertThat(ts.get(dt(2015, 1, 6))).hasValue(13d);
+    assertThat(ts.get(dt(2015, 1, 7))).hasValue(14d);
+    assertThat(ts.get(dt(2015, 1, 8))).hasValue(15d);
+    assertThat(ts.get(dt(2015, 1, 9))).hasValue(16d);
   }
 
   public void roundTrip() {
@@ -860,6 +861,88 @@ public class DenseLocalDateDoubleTimeSeriesTest {
     Map<LocalDate, Double> out = ts.stream()
         .collect(Guavate.toImmutableMap(LocalDateDoublePoint::getDate, LocalDateDoublePoint::getValue));
     assertThat(out).isEqualTo(in);
+  }
+
+  public void partitionEmptySeries() {
+
+    Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partitioned =
+        LocalDateDoubleTimeSeries.empty().partition((ld, d) -> ld.getYear() == 2015);
+
+    assertThat(partitioned.getFirst()).isEqualTo(LocalDateDoubleTimeSeries.empty());
+    assertThat(partitioned.getSecond()).isEqualTo(LocalDateDoubleTimeSeries.empty());
+  }
+
+  public void partitionSeries() {
+
+    Map<LocalDate, Double> in = ImmutableMap.<LocalDate, Double>builder()
+        .put(dt(2015, 1, 1), 10d) // Thursday
+        .put(dt(2015, 1, 2), 11d) // Friday
+        .put(dt(2015, 1, 5), 12d)
+        .put(dt(2015, 1, 6), 13d)
+        .put(dt(2015, 1, 7), 14d)
+        .put(dt(2015, 1, 8), 15d) // Thursday
+        .put(dt(2015, 1, 9), 16d) // Friday
+        .build();
+
+    LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(in).build();
+
+    Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partitioned =
+        ts.partition((ld, d) -> ld.getDayOfMonth() % 2 == 0);
+
+    LocalDateDoubleTimeSeries even = partitioned.getFirst();
+    LocalDateDoubleTimeSeries odd = partitioned.getSecond();
+
+    assertThat(even.size()).isEqualTo(3);
+    assertThat(even.get(dt(2015, 1, 2))).hasValue(11d);
+    assertThat(even.get(dt(2015, 1, 6))).hasValue(13d);
+    assertThat(even.get(dt(2015, 1, 8))).hasValue(15d);
+
+    assertThat(odd.size()).isEqualTo(4);
+    assertThat(odd.get(dt(2015, 1, 1))).hasValue(10d);
+    assertThat(odd.get(dt(2015, 1, 5))).hasValue(12d);
+    assertThat(odd.get(dt(2015, 1, 7))).hasValue(14d);
+    assertThat(odd.get(dt(2015, 1, 9))).hasValue(16d);
+  }
+
+  public void partitionByValueEmptySeries() {
+
+    Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partitioned =
+        LocalDateDoubleTimeSeries.empty().partitionByValue(d -> d > 10);
+
+    assertThat(partitioned.getFirst()).isEqualTo(LocalDateDoubleTimeSeries.empty());
+    assertThat(partitioned.getSecond()).isEqualTo(LocalDateDoubleTimeSeries.empty());
+  }
+
+  public void partitionByValueSeries() {
+
+    Map<LocalDate, Double> in = ImmutableMap.<LocalDate, Double>builder()
+        .put(dt(2015, 1, 1), 10d) // Thursday
+        .put(dt(2015, 1, 2), 11d) // Friday
+        .put(dt(2015, 1, 5), 12d)
+        .put(dt(2015, 1, 6), 13d)
+        .put(dt(2015, 1, 7), 14d)
+        .put(dt(2015, 1, 8), 15d) // Thursday
+        .put(dt(2015, 1, 9), 16d) // Friday
+        .build();
+
+    LocalDateDoubleTimeSeries ts = LocalDateDoubleTimeSeries.builder().putAll(in).build();
+
+    Pair<LocalDateDoubleTimeSeries, LocalDateDoubleTimeSeries> partitioned =
+        ts.partitionByValue(d -> d < 12 || d > 15);
+
+    LocalDateDoubleTimeSeries extreme = partitioned.getFirst();
+    LocalDateDoubleTimeSeries mid = partitioned.getSecond();
+
+    assertThat(extreme.size()).isEqualTo(3);
+    assertThat(extreme.get(dt(2015, 1, 1))).hasValue(10d);
+    assertThat(extreme.get(dt(2015, 1, 2))).hasValue(11d);
+    assertThat(extreme.get(dt(2015, 1, 9))).hasValue(16d);
+
+    assertThat(mid.size()).isEqualTo(4);
+    assertThat(mid.get(dt(2015, 1, 5))).hasValue(12d);
+    assertThat(mid.get(dt(2015, 1, 6))).hasValue(13d);
+    assertThat(mid.get(dt(2015, 1, 7))).hasValue(14d);
+    assertThat(mid.get(dt(2015, 1, 8))).hasValue(15d);
   }
 
   private LocalDate dt(int yr, int mth, int day) {


### PR DESCRIPTION
Working through analytics has highlighted cases where timeseries are partitioned into 2 new series via a predicate. Thiscan now be handled using new methods on ``LocalDateDoubleTimeSeries``.