### PR TITLE
STR-51 - Result.ofNullable

### DIFF
--- a/modules/collect/src/main/java/com/opengamma/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/collect/result/Result.java
@@ -16,6 +16,8 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
+import javax.annotation.Nullable;
+
 import org.joda.beans.Bean;
 import org.joda.beans.BeanBuilder;
 import org.joda.beans.BeanDefinition;
@@ -302,6 +304,39 @@ public final class Result<T>
       throw new IllegalArgumentException("All results were successes");
     }
     return new Result<>(Failure.of(items));
+  }
+
+  /**
+   * Returns a success result containing the value if it is non-null, else returns a failure result
+   * with the specified reason and message.
+   * <p>
+   * This is useful for interoperability with APIs that return {@code null}, for example {@code Map.get()}, where
+   * a missing value should be treated as a failure.
+   * <p>
+   * The message is produced using a template that contains zero to many "{}" placeholders.
+   * Each placeholder is replaced by the next available argument.
+   * If there are too few arguments, then the message will be left with placeholders.
+   * If there are too many arguments, then the excess arguments are appended to the
+   * end of the message. No attempt is made to format the arguments.
+   * See {@link Messages#format(String, Object...)} for more details.
+   *
+   * @param <R> the expected type of the result
+   * @param reason  the reason for the failure
+   * @param message  a message explaining the failure, uses "{}" for inserting {@code messageArgs}
+   * @param messageArgs  the arguments for the message
+   * @return a success result if the value is non-null, else a failure result
+   */
+  public static <R> Result<R> ofNullable(
+      @Nullable R value,
+      FailureReason reason,
+      String message,
+      Object... messageArgs) {
+
+    if (value != null) {
+      return success(value);
+    } else {
+      return failure(reason, message, messageArgs);
+    }
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/collect/result/Result.java
@@ -349,11 +349,7 @@ public final class Result<T>
    * @return a success result if the value is non-null, else a failure result
    */
   public static <R> Result<R> ofNullable(@Nullable R value) {
-    if (value != null) {
-      return success(value);
-    } else {
-      return failure(FailureReason.MISSING_DATA, "Found null where a value was expected");
-    }
+    return ofNullable(value, FailureReason.MISSING_DATA, "Found null where a value was expected");
   }
 
   //-------------------------------------------------------------------------

--- a/modules/collect/src/main/java/com/opengamma/collect/result/Result.java
+++ b/modules/collect/src/main/java/com/opengamma/collect/result/Result.java
@@ -339,6 +339,23 @@ public final class Result<T>
     }
   }
 
+  /**
+   * Returns a success result containing the value if it is non-null, else returns a failure result
+   * with a reason of {@link FailureReason#MISSING_DATA} and message to say an unexpected null was found.
+   * <p>
+   * This is useful for interoperability with APIs that can return {@code null} but where null is not expected.
+   *
+   * @param <R> the expected type of the result
+   * @return a success result if the value is non-null, else a failure result
+   */
+  public static <R> Result<R> ofNullable(@Nullable R value) {
+    if (value != null) {
+      return success(value);
+    } else {
+      return failure(FailureReason.MISSING_DATA, "Found null where a value was expected");
+    }
+  }
+
   //-------------------------------------------------------------------------
   /**
    * Checks if all the results are successful.


### PR DESCRIPTION
This PR adds the method ``Result.ofNullable``. It returns a success result for a value if the value is non-null, else it returns a failure result. Useful for interop with APIs that return null where a missing value should be treated as a failure.